### PR TITLE
[Feat] #3 편지지 공통 컴포넌트 제작

### DIFF
--- a/src/components/LetterTextBox.tsx
+++ b/src/components/LetterTextBox.tsx
@@ -1,33 +1,54 @@
 import { useState, type ChangeEvent } from 'react';
 
-const LetterTextBox = () => {
-  const [title, setTitle] = useState('');
-  const [titleTouched, setTitleTouched] = useState(false);
-  const [context, setContext] = useState('');
+type LetterTextBoxValue = {
+  title: string;
+  content: string;
+};
 
-  const LENGTH = {
-    TITLE: { MIN: 3, MAX: 20 },
-    CONTENT: { MAX: 500 },
-  } as const;
+type LetterTextBoxProps = {
+  value: LetterTextBoxValue;
+  // eslint-disable-next-line no-unused-vars
+  onChange: (next: LetterTextBoxValue) => void;
+  // 부모 className에 w, h값 명시하여 사용해주시면 됩니다
+  className?: string;
+};
+
+const LENGTH = {
+  TITLE: { MIN: 3, MAX: 20 },
+  CONTENT: { MAX: 500 },
+} as const;
+
+const LetterTextBox = ({ value, onChange, className }: LetterTextBoxProps) => {
+  const [titleTouched, setTitleTouched] = useState(false);
 
   const handleTitleChange = (e: ChangeEvent<HTMLInputElement>) => {
-    const next = e.target.value;
-    setTitle(next.length <= LENGTH.TITLE.MAX ? next : next.slice(0, LENGTH.TITLE.MAX));
+    const nextTitle = e.target.value;
+    onChange({
+      ...value,
+      title:
+        nextTitle.length <= LENGTH.TITLE.MAX ? nextTitle : nextTitle.slice(0, LENGTH.TITLE.MAX),
+    });
   };
 
-  const handleContextChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
-    const next = e.target.value;
-    setContext(next.length <= LENGTH.CONTENT.MAX ? next : next.slice(0, LENGTH.CONTENT.MAX));
+  const handleContentChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
+    const nextContent = e.target.value;
+    onChange({
+      ...value,
+      content:
+        nextContent.length <= LENGTH.CONTENT.MAX
+          ? nextContent
+          : nextContent.slice(0, LENGTH.CONTENT.MAX),
+    });
   };
 
-  const titleTooShort = title.length > 0 && title.length < LENGTH.TITLE.MIN;
+  const titleTooShort = value.title.length > 0 && value.title.length < LENGTH.TITLE.MIN;
   const showTitleError = titleTouched && titleTooShort;
 
   return (
-    <div className='w-full h-full flex flex-col'>
+    <div className={`flex flex-col ${className ?? ''}`}>
       <div className='h-[46px] shrink-0 rounded-t-md bg-[#EFEFEF] px-4 py-2.5 shadow-sm'>
         <input
-          value={title}
+          value={value.title}
           onChange={handleTitleChange}
           onBlur={() => setTitleTouched(true)}
           className='w-full bg-transparent text-lg font-medium text-gray-800 placeholder:text-[#8C8C8C] focus:outline-none'
@@ -41,8 +62,8 @@ const LetterTextBox = () => {
 
       <div className='flex-1 rounded-b-md border border-t-0 border-gray-200 bg-white shadow-sm overflow-hidden flex flex-col'>
         <textarea
-          value={context}
-          onChange={handleContextChange}
+          value={value.content}
+          onChange={handleContentChange}
           className='flex-1 w-full resize-none bg-transparent px-4 py-3 text-base text-gray-800 placeholder:text-gray-500 focus:outline-none overflow-y-auto'
           placeholder={`오늘의 질문을 읽고 
 얘기해보고 싶은 내용이나 주제가 있나요?
@@ -51,7 +72,7 @@ const LetterTextBox = () => {
         />
 
         <div className='shrink-0 flex items-center justify-end px-3 py-2 text-sm text-gray-500 tabular-nums'>
-          {context.length} / {LENGTH.CONTENT.MAX}
+          {value.content.length} / {LENGTH.CONTENT.MAX}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## 📂 관련 이슈

- closes #2

---

## 🛠️ 작업 사항

- [x] 전체 스타일 구현
- [x] 제목 입력란 구현
- [x] 내용 입력란 구현
- [ ] 에러 핸들링 (제목 3자 미만 / 20자 초과 / 내용 0자 미만 / 500자 초과)

---

## 📸 관련 이미지 (스크린샷 또는 동영상)

https://github.com/user-attachments/assets/9bec18be-6019-4761-bbe5-e4ee9c2afddb

https://github.com/user-attachments/assets/60f3271a-2fbb-498d-bed7-193d501e510d

---

## 💬 향후 계획 및 사용 방법

> 💡 에러 핸들링 개선 필요. 현재는 3자 미만 -> 에러 메세지, 초과일 경우 작성 불가
> 💡 박스 전체 크기는 명시가 필요합니다. 다만 **제목 입력란은 h-[46px]으로 고정되어 있습니다!**

> 💡 사용하실 땐 className='w-[000px] h-[000px]' 이렇게 크기만 명시해서 사용해주시면 됩니다.

---

## 💬 코드 리뷰 반영 내용 (수정 내용)

> **1. LENGTH 상수를 컴포넌트 외부로 분리**
> 불필요한 객체 재생성을 방지하기 위해 컴포넌트 외부로 분리하여 유지보수성을 개선하였습니다.

> **2. 변수명 수정**
> context -> content로 도메인 의미를 보다 정확하게 하였습니다.

> **3. LetterTextBox를 Controlled 컴포넌트로 전환**
> LetterTextBox를 value(title, content)와 onChange 기반의 Controlled 컴포넌트로 전환하여 상위에서 상태 관리 및 전달이 가능하도록 개선하였습니다.  
 