### PR TITLE
[Feat] #5 상단 헤더 공통 컴포넌트 제작

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "jobmate",
+  "name": "soksak",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "jobmate",
+      "name": "soksak",
       "version": "0.0.0",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
@@ -17,6 +17,7 @@
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "react-hook-form": "^7.68.0",
+        "react-icons": "^5.5.0",
         "react-router-dom": "^7.9.5",
         "tailwindcss": "^4.1.17",
         "vite-plugin-svgr": "^4.5.0",
@@ -4242,6 +4243,15 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
+      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-refresh": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-hook-form": "^7.68.0",
+    "react-icons": "^5.5.0",
     "react-router-dom": "^7.9.5",
     "tailwindcss": "^4.1.17",
     "vite-plugin-svgr": "^4.5.0",

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -1,0 +1,19 @@
+import type { ReactNode } from "react";
+
+type HeaderProps = {
+    children: ReactNode;
+    className?: string; //스타일 추가 혹은 수정
+    
+}
+
+const Header = ({ children,className } : HeaderProps ) => {
+    return (
+        <header className={`flex w-full max-w-[375px] mx-auto
+             px-[10px] justify-center items-center relative
+             bg-white border-b-2 border-white ${className}`}>
+            {children}
+        </header>
+    );
+}
+
+export default Header;

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -9,8 +9,8 @@ type HeaderProps = {
 const Header = ({ children,className } : HeaderProps ) => {
     return (
         <header className={`flex w-full max-w-[375px] mx-auto
-             px-[10px] justify-center items-center relative
-             bg-white border-b-2 border-white ${className}`}>
+             px-[10px]  justify-center items-center relative
+             bg-white ${className}`}>
             {children}
         </header>
     );

--- a/src/components/common/headers/BackHeader.tsx
+++ b/src/components/common/headers/BackHeader.tsx
@@ -21,7 +21,7 @@ const BackHeader = ({ title,rightElement,titleClassName }: Props) => {
         aria-label="뒤로 가기"
         className="absolute left-4" // absolute로 위치 고정
       >
-        <IoChevronBackSharp className="w-5 h-5 stroke-current stroke-[2px]"/>
+        <IoChevronBackSharp className="w-5 h-5 text-current"/>
       </button>
 
       {/* 2. 타이틀 (중앙) */}

--- a/src/components/common/headers/BackHeader.tsx
+++ b/src/components/common/headers/BackHeader.tsx
@@ -1,0 +1,37 @@
+
+import { useNavigate } from 'react-router-dom';
+import Header from '../Header';
+import { IoChevronBackSharp } from "react-icons/io5";
+
+type Props = {
+  title: string;
+  rightElement?: React.ReactNode; // 완료 버튼 등 우측 요소가 필요할 때만 넣기
+  titleClassName?: string; // 타이틀 위치/스타일 추가
+};
+
+const BackHeader = ({ title,rightElement,titleClassName }: Props) => {
+  const navigate = useNavigate();
+
+  return (
+    <Header className="h-[68px]">
+     {/* 1. 뒤로가기 버튼 (왼쪽 고정) */}
+      <button 
+        onClick={() => navigate(-1)} 
+        className="absolute left-4" // absolute로 위치 고정
+      >
+        <IoChevronBackSharp className="w-5 h-5 stroke-current stroke-[2px]"/>
+      </button>
+
+      {/* 2. 타이틀 (중앙) */}
+      <h1 className={`text-lg font-semibold ${titleClassName}`}>{title}</h1>
+
+      {/* 3. 우측 요소 (있으면 렌더링) */}
+      {rightElement && (
+        <div className="absolute right-4 text-sm font-semibold">
+          {rightElement}
+        </div>
+      )}
+    </Header>
+  );
+};
+export default BackHeader;

--- a/src/components/common/headers/BackHeader.tsx
+++ b/src/components/common/headers/BackHeader.tsx
@@ -16,7 +16,9 @@ const BackHeader = ({ title,rightElement,titleClassName }: Props) => {
     <Header className="h-[68px]">
      {/* 1. 뒤로가기 버튼 (왼쪽 고정) */}
       <button 
+        type="button"
         onClick={() => navigate(-1)} 
+        aria-label="뒤로 가기"
         className="absolute left-4" // absolute로 위치 고정
       >
         <IoChevronBackSharp className="w-5 h-5 stroke-current stroke-[2px]"/>

--- a/src/components/common/headers/TitleHeader.tsx
+++ b/src/components/common/headers/TitleHeader.tsx
@@ -1,0 +1,11 @@
+import Header from "../Header";
+
+
+const TitleHeader = ({ title }: { title: string }) => {
+  return (
+    <Header className="h-[49px]">
+      <h1 className="text-lg font-semibold">{title}</h1>
+    </Header>
+  );
+};
+export default TitleHeader;

--- a/src/layouts/AppShellLayout.tsx
+++ b/src/layouts/AppShellLayout.tsx
@@ -1,10 +1,11 @@
+import BackHeader from '@/components/common/headers/BackHeader';
 import { Outlet } from 'react-router-dom';
 
 export default function AppShellLayout() {
   return (
     <div className="min-h-dvh bg-[#f5f5f5]">
       <div className="mx-auto min-h-dvh w-[375px] bg-white">
-        {/* <Header /> */}
+        <BackHeader title='친구찾기' />
         {/* <main className="flex-1 overflow-y-auto"></main> */}
         <Outlet />
         {/* <TabBar /> */}

--- a/src/layouts/AppShellLayout.tsx
+++ b/src/layouts/AppShellLayout.tsx
@@ -5,7 +5,7 @@ export default function AppShellLayout() {
   return (
     <div className="min-h-dvh bg-[#f5f5f5]">
       <div className="mx-auto min-h-dvh w-[375px] bg-white">
-        <BackHeader title='친구찾기' />
+        <BackHeader title='친구찾기' rightElement='추가' />
         {/* <main className="flex-1 overflow-y-auto"></main> */}
         <Outlet />
         {/* <TabBar /> */}


### PR DESCRIPTION
## 📂 관련 이슈

- closes #5 

---

## 🛠️ 작업 사항

- [ ]공통 헤더 레이아웃으로 기본 헤더 모양 잡기(Header)
- [ ] ttitle만 있는 헤더 구현 (TitleHeader)
- [ ] 유형2 : title과 뒤로가기 버튼, 우측요소 있는 헤더 구현 (BackHeader)

---

## 📸 관련 이미지 (스크린샷 또는 동영상)

---
TitleHeader
<img width="476" height="903" alt="image" src="https://github.com/user-attachments/assets/70157e0c-84bd-49ab-8d16-eb4aed10d88e" />
 
BackHeader
<img width="470" height="913" alt="image" src="https://github.com/user-attachments/assets/097f6e90-d407-4015-9af7-c2bacb90ad1b" />



## 💬 기타 설명

> 💡headers 파일에 TitleHeader와 BackHeader 두가지 유형으로 컴포넌트를 만들었습니다.
💡 TitleHeader는 title만 있는 헤더로 사용하시고 BackHeader는 뒤로가기 버튼과 우측 요소 사용하는 헤더로사용해주시면 됩니다.
💡Header  컴포넌트도 있으니 TitleHeader와 BackHeader 사용 어려우시면 Header 컴포넌트로 사용하셔도 좋을 것 같습니다. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 공통 헤더 컴포넌트 추가로 일관된 상단 UI 제공
  * 뒤로가기 버튼과 우측 요소를 지원하는 백헤더 추가
  * 제목 전용 헤더(타이틀 헤더) 추가
  * 앱 레이아웃에 헤더를 적용하여 친구찾기 페이지 제목 표시 개선
  * 아이콘 라이브러리 지원(react-icons ^5.5.0) 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->