### PR TITLE
[Feat] #1 버튼 공통 컴포넌트 제작

### DIFF
--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -1,3 +1,5 @@
+// 기본 버튼
+
 import React from 'react';
 import clsx from 'clsx';
 

--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import clsx from 'clsx';
+
+type ButtonColor = 'primary' | 'white' | 'grey' | 'black';
+type ButtonSize = 'large' | 'medium' | 'small' | 'small2' | 'small3';
+
+type Props = React.ButtonHTMLAttributes<HTMLButtonElement> & {
+  color?: ButtonColor;
+  size?: ButtonSize;
+  selected?: boolean;
+};
+
+const base =
+  'inline-flex items-center justify-center gap-2 rounded-lg font-medium ' +
+  'transition active:scale-[0.99] disabled:cursor-not-allowed ' +
+  'focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2';
+
+const sizeMap: Record<ButtonSize, string> = {
+  large: 'h-[48px] w-[343px] px-5 text-base',
+  medium: 'h-[56px] w-[160px] px-4 text-sm',
+  small: 'h-[48px] w-[95px] px-3 text-sm',
+  small2: 'h-[44px] w-[100px] px-3 text-sm',
+  small3: 'h-[44px] w-[72px] px-3 text-xs',
+};
+
+const colorMap: Record<ButtonColor, { normal: string; selected: string }> = {
+  primary: {
+    normal: 'bg-[#F5544C] text-white hover:bg-[#E4473F]',
+    selected: 'bg-[#B12D27] text-white',
+  },
+  white: {
+    normal: 'bg-white text-[#F5544C] border-[1px] border-[#FF7D77] hover:bg-[#FFEEED]',
+    selected: 'bg-[#FFC9C6] text-[#F5544C] border-[1px] border-[#FF7D77]',
+  },
+  grey: {
+    normal: 'bg-[#B1B3B4] text-white hover:bg-[#97999B]',
+    selected: 'bg-[#7D8082] text-white',
+  },
+  black: {
+    normal: 'bg-[#191A1A] text-white hover:bg-[#323334]',
+    selected: 'bg-[#4B4D4E] text-white',
+  },
+};
+
+export function Button({
+  color = 'primary',
+  size = 'large',
+  selected = false,
+  disabled,
+  className,
+  children,
+  type = 'button',
+  ...rest
+}: Props) {
+  const styles = colorMap[color];
+
+  return (
+    <button
+      type={type}
+      disabled={disabled}
+      aria-pressed={selected}
+      className={clsx(
+        base,
+        sizeMap[size],
+        selected ? styles.selected : styles.normal,
+        disabled && 'opacity-50 cursor-not-allowed',
+        className,
+      )}
+      {...rest}
+    >
+      <span className='leading-none'>{children}</span>
+    </button>
+  );
+}

--- a/src/components/common/CheckButton.tsx
+++ b/src/components/common/CheckButton.tsx
@@ -1,0 +1,45 @@
+import clsx from 'clsx';
+
+type Props = {
+  checked: boolean;
+  onChange: (next: boolean) => void;
+  disabled?: boolean;
+  className?: string;
+};
+
+export default function CheckButton({ checked, onChange, disabled = false, className }: Props) {
+  return (
+    <button
+      type='button'
+      aria-pressed={checked}
+      disabled={disabled}
+      onClick={() => onChange(!checked)}
+      className={clsx(
+        'flex h-[18px] w-[18px] items-center justify-center rounded-full transition',
+        checked
+          ? 'bg-[#F5544C]' // Primary/500
+          : 'border border-[#B1B3B4] bg-white',
+        disabled && 'cursor-not-allowed opacity-40',
+        className,
+      )}
+    >
+      {checked && (
+        <svg
+          width='10'
+          height='8'
+          viewBox='0 0 10 8'
+          fill='none'
+          xmlns='http://www.w3.org/2000/svg'
+        >
+          <path
+            d='M1 4L4 7L9 1'
+            stroke='white'
+            strokeWidth='1.5'
+            strokeLinecap='round'
+            strokeLinejoin='round'
+          />
+        </svg>
+      )}
+    </button>
+  );
+}

--- a/src/components/common/SelectButton.tsx
+++ b/src/components/common/SelectButton.tsx
@@ -1,0 +1,52 @@
+// src/components/common/SelectButton.tsx
+import React from 'react';
+import clsx from 'clsx';
+
+type SelectButtonSize = 'large' | 'medium';
+
+type Props = React.ButtonHTMLAttributes<HTMLButtonElement> & {
+  selected?: boolean;
+  size?: SelectButtonSize;
+};
+
+const base =
+  'inline-flex items-center justify-center rounded-full font-medium transition ' +
+  'disabled:cursor-not-allowed';
+
+const sizeMap: Record<SelectButtonSize, string> = {
+  large: 'h-[44px] w-[96px] text-sm',
+  medium: 'h-[44px] w-[80px] text-sm',
+};
+
+const variant = {
+  default: 'bg-white text-[#171717] border border-[#DEDEDE]',
+  selected: 'bg-[#FFEEED] text-[#171717] border border-[#FF7D77]',
+};
+
+export function SelectButton({
+  selected = false,
+  size = 'large',
+  disabled,
+  className,
+  children,
+  type = 'button',
+  ...rest
+}: Props) {
+  return (
+    <button
+      type={type}
+      aria-pressed={selected}
+      disabled={disabled}
+      className={clsx(
+        base,
+        sizeMap[size],
+        selected ? variant.selected : variant.default,
+        disabled && 'opacity-50',
+        className,
+      )}
+      {...rest}
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/components/common/ToggleSwitch.tsx
+++ b/src/components/common/ToggleSwitch.tsx
@@ -1,4 +1,4 @@
-// 토클 on/off 버튼
+// 토글 on/off 버튼
 
 import clsx from 'clsx';
 

--- a/src/components/common/ToggleSwitch.tsx
+++ b/src/components/common/ToggleSwitch.tsx
@@ -1,0 +1,35 @@
+// 토클 on/off 버튼
+
+import clsx from 'clsx';
+
+type Props = {
+  checked: boolean;
+  onCheckedChange: (next: boolean) => void;
+  disabled?: boolean;
+  className?: string;
+};
+
+export default function ToggleSwitch({ checked, onCheckedChange, disabled, className }: Props) {
+  return (
+    <button
+      type='button'
+      role='switch'
+      aria-checked={checked}
+      disabled={disabled}
+      onClick={() => onCheckedChange(!checked)}
+      className={clsx(
+        'relative inline-flex h-[24px] w-[48px] items-center rounded-full transition',
+        checked ? 'bg-[#FFC9C6]' : 'bg-[#646668]',
+        disabled && 'opacity-50 cursor-not-allowed',
+        className,
+      )}
+    >
+      <span
+        className={clsx(
+          'absolute left-[2px] h-[20px] w-[20px] rounded-full transition',
+          checked ? 'translate-x-[24px] bg-[#F5544C]' : 'bg-white',
+        )}
+      />
+    </button>
+  );
+}


### PR DESCRIPTION
## 📂 관련 이슈

- closes #1 

---

## 🛠️ 작업 사항

- [x] 버튼 디자인 분리
- [x] 버튼 사이즈 분리
- [x] 버튼 상태 분리
- [x] 버튼 공통 컴포넌트 제작
- [x] 정보 선택 버튼 (selected 상태 있는 버튼) 제작
- [x] 체크 버튼 (세로로 아이콘 있는 버튼) 제작
- [x] 토글 버튼 (on / off 스위치) 제작

---

## 📸 관련 이미지 (스크린샷 또는 동영상)
<img width="630" height="430" alt="스크린샷 2026-01-02 오후 9 12 40" src="https://github.com/user-attachments/assets/4de0f271-52b6-48e8-b639-51818f9418de" />

https://github.com/user-attachments/assets/d6a55961-841c-4dc4-ae64-5172eee25776




---

## 💬 기타 설명

> 💡 상태(selected/disabled)는 부모가 관리하고, Button은 표현만 담당합니다.

### Props 요약
- color?: 'primary' | 'white' | 'grey' | 'black' (기본값: primary)
- size?: 'large' | 'medium' | 'small' | 'small2' | 'small3' (기본값: large)
    사이즈별 width/height는 고정값으로 적용됩니다.
- selected?: boolean (기본값: false)
    선택 상태(토글/칩 등) 표현 용도입니다.
    disabled와 역할이 다름 (disabled는 비활성, selected는 “선택됨” UI)
- 그 외 button 기본 속성(onClick, disabled, type, aria-* 등)은 그대로 전달 가능합니다.

### 🔘 공통 버튼 컴포넌트 사용 가이드

- `Button`
  - 단순 액션용 버튼
  - 상태 관리 없음
  - color / size props만 사용

- `SelectButton`
  - 선택 여부를 표현해야 하는 경우 사용
  - selected 상태는 부모에서 제어 (controlled)

- `ToggleButton`
  - on/off 상태를 갖는 UI
  - 상태 값은 외부에서 관리 (스토어/로컬 상태)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 재사용 가능한 버튼 컴포넌트 4종 추가: 일반 버튼, 체크 버튼, 선택 버튼, 토글 스위치
  * 색상·크기·선택(selected)·비활성화 상태 등 다양한 스타일 및 상태 지원
  * 체크 버튼과 토글에 시각적 피드백 및 aria-pressed/role/aria-checked 등 접근성 속성 적용
  * 선택 버튼은 크기 옵션 제공 및 선택 상태 시 시각적 변환 처리

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->