### PR TITLE
[Feat] 후기(리뷰) 페이지 UI 구현

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -8,7 +8,7 @@ import AppShellWithTab from './layouts/AppShellWithTab';
 import MainPage from './pages/main/Mainpage';
 
 import WelcomePage from './pages/login/WelcomePage';
-import SignInPage from './pages/login/SignInPage';
+import SignInPage from './pages/login/SigninPage';
 import SignUpPage from './pages/login/SignUpPage';
 import TermsCheckPage from './pages/login/TermsCheckPage';
 
@@ -23,11 +23,6 @@ import FriendInboxPage from './pages/friend/FriendInboxPage';
 import FriendPostPage from './pages/friend/FriendPostPage';
 import FriendDraftPage from './pages/friend/FriendDraftPage';
 import FriendSentTransitionPage from './pages/friend/FriendSentTransitionPage';
-
-import AnonDraftPage from './pages/letter/AnonDraftPage';
-import OtherDraftPage from './pages/letter/OtherDraftPage';
-
-import SelfDraftPage from './pages/letter/SelfDraftPage';
 
 import LetterDecoPage from './pages/letter/LetterDecoPage';
 import LetterReportPage from './pages/LetterReportPage';
@@ -45,6 +40,7 @@ import FriendFeedPage from './pages/feed/FriendFeedPage';
 
 import LetterSendingPage from './pages/letter/LetterSendingPage';
 import ProfileSetUpPage from './pages/login/ProfileSetUpPage';
+import LetterReviewPage from './pages/letter/LetterReviewPage';
 
 // ===== Placeholders =====
 const TODOPage = () => <div />;
@@ -136,7 +132,7 @@ const router = createBrowserRouter([
           { path: 'letter/reply/:letterId', element: <TODOPage /> },
 
           { path: 'letter/report', element: <LetterReportPage /> },
-          // { path: 'letter/review/:letterId', element: <TODOPage /> },
+          { path: 'letter/review/:letterId', element: <LetterReviewPage /> },
 
           // { path: 'letter/post-self', element: <TODOPage /> },
           // { path: 'letter/loading', element: <TODOPage /> },

--- a/src/assets/icons/LoveIcon.svg
+++ b/src/assets/icons/LoveIcon.svg
@@ -1,0 +1,51 @@
+<svg width="82" height="80" viewBox="0 0 82 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_g_1171_9790)">
+<path d="M80.8838 41.5867C80.8838 64.0666 64.6624 78.3833 42.0678 78.3833C19.4731 78.3833 0.883789 63.9588 0.883789 41.4789C0.883789 18.9991 16.2869 0.883325 38.8816 0.883325C61.4762 0.883325 80.8838 19.1068 80.8838 41.5867Z" fill="#AEDEFC"/>
+</g>
+<path d="M6.71722 38.8874C6.71722 44.6886 10.6036 48.3833 16.0169 48.3833C21.4302 48.3833 25.8839 44.6608 25.8839 38.8596C25.8839 33.0583 22.1936 28.3833 16.7802 28.3833C11.3669 28.3833 6.71722 33.0861 6.71722 38.8874Z" fill="#F5544C" fill-opacity="0.25"/>
+<path d="M56.7171 43.8874C56.7171 49.6887 60.6035 53.3833 66.0168 53.3833C71.4301 53.3833 75.8838 49.6608 75.8838 43.8596C75.8838 38.0583 72.1935 33.3833 66.7802 33.3833C61.3668 33.3833 56.7171 38.0862 56.7171 43.8874Z" fill="#F5544C" fill-opacity="0.25"/>
+<path d="M28.2094 30.1754C26.9893 32.0855 28.2023 33.4599 29.4623 34.2648C30.7223 35.0697 32.7549 34.9703 33.9751 33.0602C35.1953 31.15 33.9603 28.979 32.7002 28.1741C31.4402 27.3692 29.4296 28.2652 28.2094 30.1754Z" fill="black"/>
+<path d="M56.6635 33.0575C57.4621 35.1788 55.991 36.2725 54.5917 36.7994C53.1925 37.3262 51.2244 36.8084 50.4258 34.6871C49.6272 32.5659 51.2846 30.6973 52.6839 30.1705C54.0831 29.6437 55.8649 30.9363 56.6635 33.0575Z" fill="black"/>
+<g clip-path="url(#clip0_1171_9790)" filter="url(#filter1_g_1171_9790)">
+<path d="M35.3182 24.8053C34.8763 24.4343 34.3656 24.154 33.8154 23.9805C33.2651 23.8069 32.686 23.7435 32.1112 23.7937C31.5364 23.844 30.9772 24.0071 30.4654 24.2736C29.9537 24.54 29.4994 24.9047 29.1287 25.3468L28.3591 26.2639L27.442 25.4944C26.5494 24.7454 25.3959 24.3817 24.2351 24.4832C23.0743 24.5848 22.0015 25.1433 21.2525 26.0359C20.5035 26.9285 20.1398 28.0821 20.2413 29.2428C20.3429 30.4036 20.9014 31.4765 21.794 32.2254L22.7111 32.995L29.4422 38.643L35.0902 31.9119L35.8597 30.9949C36.2307 30.5529 36.511 30.0423 36.6845 29.492C36.8581 28.9417 36.9216 28.3627 36.8713 27.7879C36.821 27.2131 36.658 26.6538 36.3915 26.1421C36.125 25.6303 35.7603 25.1761 35.3182 24.8053Z" fill="#F5544C" stroke="#F5544C" stroke-width="2.48918" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+<g clip-path="url(#clip1_1171_9790)" filter="url(#filter2_g_1171_9790)">
+<path d="M66.0262 33.1012C65.829 32.5589 65.5269 32.0609 65.1371 31.6354C64.7474 31.21 64.2776 30.8655 63.7547 30.6216C63.2318 30.3778 62.6659 30.2394 62.0895 30.2143C61.513 30.1892 60.9373 30.2779 60.3951 30.4754L59.2702 30.8848L58.8607 29.7598C58.4622 28.6649 57.645 27.7731 56.589 27.2807C55.533 26.7883 54.3246 26.7355 53.2297 27.134C52.1347 27.5325 51.2429 28.3497 50.7505 29.4057C50.2581 30.4618 50.2053 31.6702 50.6038 32.7651L51.0133 33.8901L54.0186 42.1469L62.2754 39.1417L63.4004 38.7322C63.9426 38.535 64.4407 38.2329 64.8662 37.8431C65.2916 37.4534 65.6361 36.9836 65.8799 36.4607C66.1238 35.9378 66.2622 35.3719 66.2873 34.7955C66.3124 34.219 66.2237 33.6433 66.0262 33.1012Z" fill="#F5544C" stroke="#F5544C" stroke-width="2.48918" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+<path d="M32.6758 41.9448C32.6758 41.9448 35.0292 46.7053 40.067 47.0254C45.1048 47.3455 49.2174 43.3832 49.2174 43.3832" stroke="black" stroke-width="3.33333" stroke-linecap="round"/>
+<defs>
+<filter id="filter0_g_1171_9790" x="0.000455797" y="-3.24845e-05" width="81.7667" height="79.2667" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feTurbulence type="fractalNoise" baseFrequency="0.32967033982276917 0.32967033982276917" numOctaves="3" seed="4563" />
+<feDisplacementMap in="shape" scale="1.7666665315628052" xChannelSelector="R" yChannelSelector="G" result="displacedImage" width="100%" height="100%" />
+<feMerge result="effect1_texture_1171_9790">
+<feMergeNode in="displacedImage"/>
+</feMerge>
+</filter>
+<filter id="filter1_g_1171_9790" x="18.118" y="20.6177" width="21.3646" height="21.3642" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feTurbulence type="fractalNoise" baseFrequency="0.5 0.5" numOctaves="3" seed="4563" />
+<feDisplacementMap in="shape" scale="0.60000008344650269" xChannelSelector="R" yChannelSelector="G" result="displacedImage" width="100%" height="100%" />
+<feMerge result="effect1_texture_1171_9790">
+<feMergeNode in="displacedImage"/>
+</feMerge>
+</filter>
+<filter id="filter2_g_1171_9790" x="44.0975" y="22.431" width="26.0717" height="26.0712" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feTurbulence type="fractalNoise" baseFrequency="0.5 0.5" numOctaves="3" seed="4563" />
+<feDisplacementMap in="shape" scale="0.60000008344650269" xChannelSelector="R" yChannelSelector="G" result="displacedImage" width="100%" height="100%" />
+<feMerge result="effect1_texture_1171_9790">
+<feMergeNode in="displacedImage"/>
+</feMerge>
+</filter>
+<clipPath id="clip0_1171_9790">
+<rect width="19.1667" height="19.1667" fill="white" transform="translate(18.418 22.5881) rotate(-5)"/>
+</clipPath>
+<clipPath id="clip1_1171_9790">
+<rect width="19.1667" height="19.1667" fill="white" transform="translate(52.498 22.731) rotate(25)"/>
+</clipPath>
+</defs>
+</svg>

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -1,19 +1,20 @@
-import type { ReactNode } from "react";
+import type { ReactNode } from 'react';
 
 type HeaderProps = {
-    children: ReactNode;
-    className?: string; //스타일 추가 혹은 수정
-    
-}
+  children: ReactNode;
+  className?: string; //스타일 추가 혹은 수정
+};
 
-const Header = ({ children,className } : HeaderProps ) => {
-    return (
-        <header className={`flex w-full max-w-[375px] mx-auto
+const Header = ({ children, className }: HeaderProps) => {
+  return (
+    <header
+      className={`flex w-full max-w-[375px] mx-auto
              px-[10px]  justify-center items-center relative
-             bg-white ${className}`}>
-            {children}
-        </header>
-    );
-}
+             bg-[#fafafa] ${className}`}
+    >
+      {children}
+    </header>
+  );
+};
 
 export default Header;

--- a/src/components/common/headers/BackHeader.tsx
+++ b/src/components/common/headers/BackHeader.tsx
@@ -34,10 +34,12 @@ const BackHeader = ({ title, rightElement, titleClassName, onBack }: Props) => {
       </button>
 
       {/* 2. 타이틀 (중앙) */}
-      <h1 className={`text-lg font-semibold ${titleClassName}`}>{title}</h1>
+      <h1 className={`ty-title3 ${titleClassName}`}>{title}</h1>
 
       {/* 3. 우측 요소 (있으면 렌더링) */}
-      {rightElement && <div className='absolute right-4 text-sm font-semibold'>{rightElement}</div>}
+      {rightElement && (
+        <div className='absolute right-4 ty-body4 text-(--color-text-normal)'>{rightElement}</div>
+      )}
     </Header>
   );
 };

--- a/src/components/common/headers/BackHeader.tsx
+++ b/src/components/common/headers/BackHeader.tsx
@@ -38,7 +38,9 @@ const BackHeader = ({ title, rightElement, titleClassName, onBack }: Props) => {
 
       {/* 3. 우측 요소 (있으면 렌더링) */}
       {rightElement && (
-        <div className='absolute right-4 ty-body4 text-(--color-text-normal)'>{rightElement}</div>
+        <div className='absolute right-4 ty-body4 text-[var(--color-text-normal)]'>
+          {rightElement}
+        </div>
       )}
     </Header>
   );

--- a/src/pages/letter/LetterReviewPage.tsx
+++ b/src/pages/letter/LetterReviewPage.tsx
@@ -1,0 +1,245 @@
+import React, { useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+// import { useParams } from 'react-router-dom';
+
+import BackHeader from '@/components/common/headers/BackHeader';
+import LetterEnvelope from '@/components/letters/LetterEnvelope';
+
+import SadModalIcon from '@/assets/icons/SadModalIcon.svg?react';
+import HappyModalIcon from '@/assets/icons/HappyModalIcon.svg?react';
+import LoveIcon from '@/assets/icons/LoveIcon.svg?react';
+
+import stampEx1 from '@/assets/test/stampEx1.svg';
+import stampEx2 from '@/assets/test/stampEx2.svg';
+
+type ReviewMood = 'meh' | 'good' | 'love';
+
+const MOODS: Array<{
+  key: ReviewMood;
+  label: string;
+}> = [
+  { key: 'meh', label: '그냥 그래요' },
+  { key: 'good', label: '좋아요!' },
+  { key: 'love', label: '또 만나고 싶어요' },
+];
+
+export default function LetterReviewPage() {
+  const navigate = useNavigate();
+  //   const { letterId } = useParams<{ letterId: string }>();
+
+  const [mood, setMood] = useState<ReviewMood | null>(null);
+  const [temp, setTemp] = useState<number>(0);
+  const [isSliding, setIsSliding] = useState(false);
+
+  const percent = useMemo(() => Math.min(100, Math.max(0, temp)), [temp]);
+  const canSubmit = mood !== null;
+
+  const handleSubmit = async () => {
+    if (!canSubmit) return;
+
+    // await postLetterReview({ letterId, mood, temperature: temp });
+    navigate(-1);
+  };
+
+  const testStamps = [
+    { id: 'stamp-1', src: stampEx1 },
+    { id: 'stamp-2', src: stampEx2 },
+  ];
+
+  // 피그마 봉투 사이즈 (W 174.54 / H 97.98)
+  const FIGMA_W = 174.54;
+  const FIGMA_H = 97.98;
+
+  // LetterEnvelope 기본이 296.45 x 162.52 라는 전제에서 스케일
+  const BASE_W = 296.45;
+  const scale = FIGMA_W / BASE_W; // ≈ 0.589
+  const rotateDeg = -4.03;
+
+  return (
+    <div className='min-h-dvh bg-[#FAFAFA]'>
+      <BackHeader
+        title='후기 보내기'
+        rightElement={
+          <button
+            type='button'
+            onClick={handleSubmit}
+            disabled={!canSubmit}
+            className={[
+              'ty-body4',
+              canSubmit ? 'text-[var(--color-text-default)]' : 'text-[var(--color-text-assistive)]',
+            ].join(' ')}
+          >
+            완료
+          </button>
+        }
+      />
+
+      <div className='px-5 pb-10'>
+        {/* ===== 봉투: 디자인처럼 중앙 고정 ===== */}
+        <div className='mt-6 flex flex-col items-center'>
+          <div
+            className='flex items-center justify-center'
+            style={{ width: FIGMA_W, height: FIGMA_H }}
+          >
+            <div
+              style={{
+                transform: `scale(${scale}) rotate(${rotateDeg}deg)`,
+                transformOrigin: 'center',
+              }}
+            >
+              <LetterEnvelope
+                paperColor='#EBF7DF'
+                stampSrc={testStamps[0].src}
+                stampAlt='우표 이미지'
+                className='shadow-[0_4px_12px_rgba(0,0,0,0.08)] rounded-[6px]'
+              />
+            </div>
+          </div>
+
+          <p className='mt-5 ty-title3 text-[#000000]'>파란수박님</p>
+        </div>
+
+        {/* ===== 카피 ===== */}
+        <div className='mt-8'>
+          <p className='ty-body2 text-[#000000] leading-[160%]'>
+            개굴님, 파란수박님과의 편지는 어땠나요?
+            <br />
+            편지 후기를 남겨주세요.
+          </p>
+          <p className='mt-2 ty-body5 text-[var(--color-text-alternative)] leading-[160%]'>
+            남겨주신 온도는 이후 매칭에 활용됩니다.
+          </p>
+        </div>
+
+        {/* ===== 이모지 3택1: 3열/간격/텍스트 강조 ===== */}
+        <div className='mt-7 grid grid-cols-3 gap-3'>
+          {MOODS.map((m) => {
+            const selected = mood === m.key;
+
+            // 아이콘 3개 분기
+            const Icon =
+              m.key === 'meh' ? SadModalIcon : m.key === 'love' ? LoveIcon : HappyModalIcon;
+
+            return (
+              <button
+                key={m.key}
+                type='button'
+                onClick={() => setMood(m.key)}
+                className='flex flex-col items-center'
+                aria-pressed={selected}
+              >
+                <div className='flex items-center justify-center w-[72px] h-[72px] rounded-full bg-[#E8F3FF]'>
+                  <Icon className='w-[92px] h-[77.5px]' />
+                </div>
+
+                <span
+                  className={['mt-3 ty-body5', selected ? 'text-[#F5544C]' : 'text-[#000000]'].join(
+                    ' ',
+                  )}
+                >
+                  {m.label}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+
+        {/* ===== 슬라이더 ===== */}
+        <div className='mt-10'>
+          <p className='ty-body2 text-[#000000]'>우리의 편지 온도는 어땠나요?</p>
+          <p className='mt-2 ty-body5 text-[var(--color-text-alternative)]'>
+            남겨주신 온도는 이후 매칭에 도움이 됩니다.
+          </p>
+
+          <div className='mt-5'>
+            <div
+              className='relative'
+              onMouseDown={() => setIsSliding(true)}
+              onMouseUp={() => setIsSliding(false)}
+              onMouseLeave={() => setIsSliding(false)}
+              onTouchStart={() => setIsSliding(true)}
+              onTouchEnd={() => setIsSliding(false)}
+            >
+              {(isSliding || temp !== 0) && (
+                <div
+                  className='pointer-events-none absolute -bottom-7 ml-2 ty-body4 text-[var(--color-primary-500)]'
+                  style={{
+                    left: `calc(${percent}% - 10px)`,
+                    transform: 'translateX(-50%)',
+                  }}
+                >
+                  {temp}도
+                </div>
+              )}
+
+              <input
+                type='range'
+                min={0}
+                max={100}
+                value={temp}
+                onChange={(e) => setTemp(Number(e.target.value))}
+                className='w-[320px] ml-2 appearance-none bg-transparent outline-none'
+                style={
+                  {
+                    // @ts-expect-error CSS var
+                    '--fill': `${percent}%`,
+                  } as React.CSSProperties
+                }
+              />
+
+              <style>{`
+                input[type="range"]{
+                  height: 24px;
+                }
+                input[type="range"]::-webkit-slider-runnable-track{
+                  height: 8px;
+                  border-radius: 9999px;
+                  background: linear-gradient(
+                    to right,
+                    var(--color-primary-500) 0%,
+                    var(--color-primary-500) var(--fill),
+                    #F3B6B3 var(--fill),
+                    #F3B6B3 100%
+                  );
+                }
+                input[type="range"]::-webkit-slider-thumb{
+                  -webkit-appearance: none;
+                  width: 22px;
+                  height: 22px;
+                  margin-top: -7px;
+                  border-radius: 9999px;
+                  background: var(--color-primary-500);
+                  border: none;
+                  box-shadow: 0 1px 2px rgba(0,0,0,0.12);
+                }
+                input[type="range"]::-moz-range-track{
+                  height: 8px;
+                  border-radius: 9999px;
+                  background: #F3B6B3;
+                }
+                input[type="range"]::-moz-range-progress{
+                  height: 8px;
+                  border-radius: 9999px;
+                  background: var(--color-primary-500);
+                }
+                input[type="range"]::-moz-range-thumb{
+                  width: 22px;
+                  height: 22px;
+                  border-radius: 9999px;
+                  background: var(--color-primary-500);
+                  border: none;
+                  box-shadow: 0 1px 2px rgba(0,0,0,0.12);
+                }
+              `}</style>
+            </div>
+
+            <div className='mt-1 flex items-center justify-between ty-body5 text-[var(--color-text-normal)]'>
+              <span>0도</span>
+              <span>100도</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/letter/LetterReviewPage.tsx
+++ b/src/pages/letter/LetterReviewPage.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-// import { useParams } from 'react-router-dom';
+// import { useParams } from 'react-router-dom'; TODO
 
 import BackHeader from '@/components/common/headers/BackHeader';
 import LetterEnvelope from '@/components/letters/LetterEnvelope';
@@ -25,7 +25,7 @@ const MOODS: Array<{
 
 export default function LetterReviewPage() {
   const navigate = useNavigate();
-  //   const { letterId } = useParams<{ letterId: string }>();
+  //   const { letterId } = useParams<{ letterId: string }>(); TODO
 
   const [mood, setMood] = useState<ReviewMood | null>(null);
   const [temp, setTemp] = useState<number>(0);
@@ -37,7 +37,7 @@ export default function LetterReviewPage() {
   const handleSubmit = async () => {
     if (!canSubmit) return;
 
-    // await postLetterReview({ letterId, mood, temperature: temp });
+    // await postLetterReview({ letterId, mood, temperature: temp }); TODO
     navigate(-1);
   };
 

--- a/src/pages/letter/LetterReviewPage.tsx
+++ b/src/pages/letter/LetterReviewPage.tsx
@@ -128,7 +128,8 @@ export default function LetterReviewPage() {
                 className='flex flex-col items-center'
                 aria-pressed={selected}
               >
-                <div className='flex items-center justify-center w-[72px] h-[72px] rounded-full bg-[#E8F3FF]'>
+                {/* div는 레이아웃 전용 래퍼 */}
+                <div className='flex items-center justify-center rounded-full'>
                   <Icon className='w-[92px] h-[77.5px]' />
                 </div>
 


### PR DESCRIPTION
## 📂 관련 이슈

- closes #52 

---

## 🛠️ 작업 사항

- [x] letter/review/:letterId 라우팅 추가
- [x] 후기 페이지 UI 구현(봉투, 이모지 3종 - 러브 이모지 추가, 편지 온도 슬라이더(0~100) 스타일링(트랙 fill + thumb 스타일))
- [x] 헤더 배경색 #FAFAFA로 통일(피그마 기준)

---

## 📸 관련 이미지 (스크린샷 또는 동영상)

https://github.com/user-attachments/assets/3b826dc3-56d0-4b1b-beb5-c89bfa0f2112




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 편지 검토 페이지 추가: 봉투 UI, 감정 선택(보통/좋음/사랑함), 온도 슬라이더(0–100)로 제출 가능하며 감정 선택 시에만 제출 활성화

* **Style**
  * 헤더 기본 배경을 연한 회색으로 조정
  * 제목 및 우측 요소의 타이포그래피·스타일 정리

* **Refactor**
  * 라우팅 정리: 편지 검토 페이지가 공개 경로에 포함되고 일부 드래프트 관련 경로 제거

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->