### PR TITLE
[Feat] API 공통 axios 인스턴스 및 인터셉터 구현

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -3,7 +3,7 @@ import axios from 'axios';
 export const baseURL = import.meta.env.VITE_API_URL;
 
 if (!baseURL) {
-  console.error(
+  throw new Error(
     '[axiosInstance] VITE_API_URL 이 설정되어 있지 않습니다. .env.local 을 확인하세요.',
   );
 }

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -1,1 +1,34 @@
-// init
+import axios from 'axios';
+
+export const baseURL = import.meta.env.VITE_API_URL;
+
+if (!baseURL) {
+  console.error(
+    '[axiosInstance] VITE_API_URL 이 설정되어 있지 않습니다. .env.local 을 확인하세요.',
+  );
+}
+
+export const axiosInstance = axios.create({
+  baseURL,
+  withCredentials: true,
+});
+
+// 401 인터셉터 공통 함수 - 401에러 시 온보딩 페이지로 리다이렉트
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const setupInterceptor = (instance: any) => {
+  instance.interceptors.response.use(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (response: any) => response,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (error: any) => {
+      if (error.response?.status === 401) {
+        // 인증 만료 → 온보딩
+        // TODO: refresh token 로직
+        window.location.href = '/onboarding';
+      }
+      return Promise.reject(error);
+    },
+  );
+};
+
+setupInterceptor(axiosInstance);

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -24,7 +24,9 @@ const setupInterceptor = (instance: any) => {
       if (error.response?.status === 401) {
         // 인증 만료 → 온보딩
         // TODO: refresh token 로직
-        window.location.href = '/onboarding';
+        if (window.location.pathname !== '/onboarding') {
+          window.location.replace('/onboarding');
+        }
       }
       return Promise.reject(error);
     },


### PR DESCRIPTION
## 📂 관련 이슈

- closes #63 

---

## 🛠️ 작업 사항

- [x] axios 인스턴스 도입
- [x] 공통 인터셉터 추가

---

## 💬 기타 설명

### 🔧 API 사용 가이드 (TanStack Query 연계)

- 본 PR에서 추가한 `api.ts`의 axios 인스턴스는  
  **TanStack Query (`useQuery`, `useMutation`)와 함께 사용하는 것을 전제로 설계되었습니다.**

- 모든 API 요청은
  - `axiosInstance`를 통해 호출하고
  - 각 도메인별 API 함수 (`userApi`, `friendApi` 등)에서 래핑한 뒤
  - 컴포넌트에서는 TanStack Query 훅을 통해 사용하기를 권장합니다.

- 이를 통해
  - 요청 로직의 일관성
  - 전역 에러(401) 처리의 통합
  - 캐싱 / 리페치 / 로딩 상태 관리의 표준화
  를 목표로 합니다.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **인프라 개선**
  * API 통신을 위한 중앙화된 설정을 도입했습니다.
  * 환경 변수 기반 API 엔드포인트 설정을 추가했습니다.
  * 인증 오류(401) 발생 시 온보딩 화면으로 자동 리다이렉트 기능을 구현했습니다.
  * 요청 시 자격 증명 유지 옵션을 적용했습니다.
  * 인증 토큰 갱신 로직은 추후 구현 예정입니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->