### PR TITLE
[Feat] 편지 전송 완료 처리

### DIFF
--- a/src/components/modal/ModalRoot.tsx
+++ b/src/components/modal/ModalRoot.tsx
@@ -3,9 +3,10 @@ import OnboardingSkipConfirmModal from '@/modals/OnboardingSkipConfirmModal';
 import FriendAddedModal from '@/modals/FriendAddedModal';
 
 import { useModalStore } from '@/stores/modalStore';
-import LetterSendingConfirm from '@/modals/LetterSendingConfirmModal';
+import LetterSendingConfirmModal from '@/modals/LetterSendingConfirmModal';
 import FriendRequestModal from '@/modals/FriendRequestModal';
 import FriendRequestFailedModal from '@/modals/FriendRequestFailedModal';
+import LetterSendingFailedModal from '@/modals/LetterSendingFailedModal';
 
 export default function ModalRoot() {
   const { activeModal } = useModalStore();
@@ -21,7 +22,10 @@ export default function ModalRoot() {
       return <FriendAddedModal />;
 
     case 'letterSendingConfirm':
-      return <LetterSendingConfirm />;
+      return <LetterSendingConfirmModal />;
+
+    case 'letterSendingFailed':
+      return <LetterSendingFailedModal />;
 
     case 'friendRequest':
       return <FriendRequestModal />;

--- a/src/components/modal/ModalRoot.tsx
+++ b/src/components/modal/ModalRoot.tsx
@@ -5,6 +5,7 @@ import FriendAddedModal from '@/modals/FriendAddedModal';
 import { useModalStore } from '@/stores/modalStore';
 import LetterSendingConfirm from '@/modals/LetterSendingConfirmModal';
 import FriendRequestModal from '@/modals/FriendRequestModal';
+import FriendRequestFailedModal from '@/modals/FriendRequestFailedModal';
 
 export default function ModalRoot() {
   const { activeModal } = useModalStore();
@@ -24,6 +25,9 @@ export default function ModalRoot() {
 
     case 'friendRequest':
       return <FriendRequestModal />;
+
+    case 'friendRequestFailed':
+      return <FriendRequestFailedModal />;
 
     default:
       return null;

--- a/src/modals/FriendRequestFailedModal.tsx
+++ b/src/modals/FriendRequestFailedModal.tsx
@@ -1,0 +1,53 @@
+import ModalFrame from '@/components/modal/ModalFrame';
+import { useModalStore } from '@/stores/modalStore';
+
+import SadModalIcon from '@/assets/icons/SadModalIcon.svg?react';
+
+export default function FriendRequestFailedModal() {
+  const { closeModal, payload } = useModalStore();
+
+  const handleStay = () => {
+    closeModal();
+  };
+
+  const handleSubmit = () => {
+    // TODO : 재시도 로직 -> n번 이상 반복될 경우 처리 어떻게 할 것인지
+    payload?.onConfirmRequestAgain?.();
+    closeModal();
+  };
+
+  return (
+    <ModalFrame>
+      <div
+        className='w-[320px] max-w-[92vw] overflow-hidden rounded-xl bg-[#F2F2F2] shadow-[0_30px_80px_rgba(0,0,0,0.55)]'
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* 본문 */}
+        <div className='px-6 py-6 pt-8 text-center flex flex-col items-center justify-center gap-4'>
+          <p className='text-[18px] font-semibold text-[#000] leading-[28.8px]'></p>
+
+          <SadModalIcon />
+        </div>
+
+        {/* 하단 버튼 바 */}
+        <div className='grid grid-cols-2'>
+          <button
+            type='button'
+            onClick={handleStay}
+            className='h-14 bg-[#B1B3B4] text-white ty-body3'
+          >
+            취소
+          </button>
+
+          <button
+            type='button'
+            onClick={handleSubmit}
+            className='h-14 bg-[#F5544C] text-white ty-body3'
+          >
+            다시 전송할게요
+          </button>
+        </div>
+      </div>
+    </ModalFrame>
+  );
+}

--- a/src/modals/FriendRequestFailedModal.tsx
+++ b/src/modals/FriendRequestFailedModal.tsx
@@ -24,7 +24,11 @@ export default function FriendRequestFailedModal() {
       >
         {/* 본문 */}
         <div className='px-6 py-6 pt-8 text-center flex flex-col items-center justify-center gap-4'>
-          <p className='text-[18px] font-semibold text-[#000] leading-[28.8px]'></p>
+          <p className='text-[18px] font-semibold text-[#000] leading-[28.8px]'>
+            친구 신청에 실패했어요.
+            <br />
+            다시 시도하시겠어요?
+          </p>
 
           <SadModalIcon />
         </div>

--- a/src/modals/LetterSendingConfirmModal.tsx
+++ b/src/modals/LetterSendingConfirmModal.tsx
@@ -3,7 +3,7 @@ import { useModalStore } from '@/stores/modalStore';
 import HappyModalIcon from '@/assets/icons/HappyModalIcon.svg?react';
 import { useLocation } from 'react-router-dom';
 
-export default function LetterSendingConfirm() {
+export default function LetterSendingConfirmModal() {
   const { closeModal, payload } = useModalStore();
   const { pathname } = useLocation();
 

--- a/src/modals/LetterSendingFailedModal.tsx
+++ b/src/modals/LetterSendingFailedModal.tsx
@@ -24,7 +24,11 @@ export default function LetterSendingFailedModal() {
       >
         {/* 본문 */}
         <div className='px-6 py-6 pt-8 text-center flex flex-col items-center justify-center gap-4'>
-          <p className='text-[18px] font-semibold text-[#000] leading-[28.8px]'></p>
+          <p className='text-[18px] font-semibold text-[#000] leading-[28.8px]'>
+            전송에 실패했어요.
+            <br />
+            다시 시도하시겠습니까?
+          </p>
 
           <SadModalIcon />
         </div>

--- a/src/modals/LetterSendingFailedModal.tsx
+++ b/src/modals/LetterSendingFailedModal.tsx
@@ -1,0 +1,53 @@
+import ModalFrame from '@/components/modal/ModalFrame';
+import { useModalStore } from '@/stores/modalStore';
+
+import SadModalIcon from '@/assets/icons/SadModalIcon.svg?react';
+
+export default function LetterSendingFailedModal() {
+  const { closeModal, payload } = useModalStore();
+
+  const handleStay = () => {
+    closeModal();
+  };
+
+  const handleSubmit = () => {
+    // TODO : 재시도 로직 -> n번 이상 반복될 경우 처리 어떻게 할 것인지
+    payload?.onConfirmSendingAgain?.();
+    closeModal();
+  };
+
+  return (
+    <ModalFrame>
+      <div
+        className='w-[320px] max-w-[92vw] overflow-hidden rounded-xl bg-[#F2F2F2] shadow-[0_30px_80px_rgba(0,0,0,0.55)]'
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* 본문 */}
+        <div className='px-6 py-6 pt-8 text-center flex flex-col items-center justify-center gap-4'>
+          <p className='text-[18px] font-semibold text-[#000] leading-[28.8px]'></p>
+
+          <SadModalIcon />
+        </div>
+
+        {/* 하단 버튼 바 */}
+        <div className='grid grid-cols-2'>
+          <button
+            type='button'
+            onClick={handleStay}
+            className='h-14 bg-[#B1B3B4] text-white ty-body3'
+          >
+            취소
+          </button>
+
+          <button
+            type='button'
+            onClick={handleSubmit}
+            className='h-14 bg-[#F5544C] text-white ty-body3'
+          >
+            다시 전송할게요
+          </button>
+        </div>
+      </div>
+    </ModalFrame>
+  );
+}

--- a/src/pages/letter/LetterSendingPage.tsx
+++ b/src/pages/letter/LetterSendingPage.tsx
@@ -40,7 +40,6 @@ const LetterSendingPage = () => {
 
     const sendLetter = async () => {
       try {
-        if (import.meta.env.DEV) throw new Error('mock fail');
         // TODO : 실제 전송 API 호출
 
         if (cancelled) return;
@@ -67,8 +66,10 @@ const LetterSendingPage = () => {
         navigate('/home/main', { replace: true });
       } catch (e) {
         if (cancelled) return;
+        // TODO : 전역 상태 store 만든 후 편지 전송 실패 처리 리팩토링
+        // 아래 모달은 여기서 띄우면 안됨.
+        // 이전 페이지로 이동한 뒤 모달을 띄우고 싶으나, navigate는 언마운트 후 리렌더링이 됨
         openModal('letterSendingFailed');
-        navigate(-1);
       }
     };
     sendLetter();

--- a/src/pages/letter/LetterSendingPage.tsx
+++ b/src/pages/letter/LetterSendingPage.tsx
@@ -40,6 +40,7 @@ const LetterSendingPage = () => {
 
     const sendLetter = async () => {
       try {
+        if (import.meta.env.DEV) throw new Error('mock fail');
         // TODO : 실제 전송 API 호출
 
         if (cancelled) return;
@@ -50,6 +51,7 @@ const LetterSendingPage = () => {
           const isTenTimes = true;
 
           if (isTenTimes) {
+            await delay(3000);
             navigate('/friend/sent-transition', { replace: true });
             return;
           }
@@ -57,6 +59,8 @@ const LetterSendingPage = () => {
 
         // TODO : 10회 미만일 때 성공 처리
         showToast('편지를 전송했어요!', 'success');
+        // 토스트 확인 + sending 페이지 확인 후 전송하기 위해 delay 설정
+        // 실제 서버 연결시, 3s 이상 걸릴 경우 sending 화면 지속되나?
         await delay(3000);
 
         if (cancelled) return;

--- a/src/pages/letter/LetterSendingPage.tsx
+++ b/src/pages/letter/LetterSendingPage.tsx
@@ -77,7 +77,7 @@ const LetterSendingPage = () => {
     return () => {
       cancelled = true;
     };
-  }, [isFriendSending, navigate, openModal]);
+  }, [isFriendSending, navigate, openModal, showToast]);
 
   const getTargetText = () => {
     if (pathname.includes('/letter/other/sending') || pathname.includes('/letter/anon/sending')) {

--- a/src/pages/letter/LetterSendingPage.tsx
+++ b/src/pages/letter/LetterSendingPage.tsx
@@ -1,11 +1,15 @@
 import LetterEnvelope from '@/components/letters/LetterEnvelope';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 import stampEx1 from '@/assets/test/stampEx1.svg';
 import stampEx2 from '@/assets/test/stampEx2.svg';
+import { useEffect } from 'react';
+import { useModalStore } from '@/stores/modalStore';
 
 const LetterSendingPage = () => {
   const { pathname } = useLocation();
+  const { openModal } = useModalStore();
+  const navigate = useNavigate();
 
   const sender = '개굴';
   const receiver = '파란수박';
@@ -21,6 +25,34 @@ const LetterSendingPage = () => {
     { id: 'stamp-1', src: stampEx1 },
     { id: 'stamp-2', src: stampEx2 },
   ];
+
+  const isFriendSending = pathname.includes('/letter/friend/sending');
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const sendLetter = async () => {
+      try {
+        // TODO : 실제 전송 API 호출
+
+        if (cancelled) return;
+
+        if (isFriendSending) {
+          // TODO : 10회 주고받았는지 확인하는 API/값
+          // 아래는 mock data
+          const isTenTimes = true;
+
+          if (isTenTimes) {
+            navigate('/friend/sent-transition', { replace: true });
+            return;
+          }
+        }
+      } catch (e) {
+        if (cancelled) return;
+        openModal('letterSendingFailed');
+      }
+    };
+  });
 
   const getTargetText = () => {
     if (pathname.includes('/letter/other/sending') || pathname.includes('/letter/anon/sending')) {

--- a/src/pages/letter/LetterSendingPage.tsx
+++ b/src/pages/letter/LetterSendingPage.tsx
@@ -5,11 +5,17 @@ import stampEx1 from '@/assets/test/stampEx1.svg';
 import stampEx2 from '@/assets/test/stampEx2.svg';
 import { useEffect } from 'react';
 import { useModalStore } from '@/stores/modalStore';
+import useToast from '@/hooks/useToast';
+import ToastPopup from '@/components/ToastPopup';
 
 const LetterSendingPage = () => {
   const { pathname } = useLocation();
   const { openModal } = useModalStore();
   const navigate = useNavigate();
+  const { toast, visible, showToast, closeToast } = useToast({
+    duration: 3000,
+    exitMs: 300,
+  });
 
   const sender = '개굴';
   const receiver = '파란수박';
@@ -30,6 +36,7 @@ const LetterSendingPage = () => {
 
   useEffect(() => {
     let cancelled = false;
+    const delay = (ms: number) => new Promise((res) => setTimeout(res, ms));
 
     const sendLetter = async () => {
       try {
@@ -47,12 +54,25 @@ const LetterSendingPage = () => {
             return;
           }
         }
+
+        // TODO : 10회 미만일 때 성공 처리
+        showToast('편지를 전송했어요!', 'success');
+        await delay(3000);
+
+        if (cancelled) return;
+        navigate('/home/main', { replace: true });
       } catch (e) {
         if (cancelled) return;
         openModal('letterSendingFailed');
+        navigate(-1);
       }
     };
-  });
+    sendLetter();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isFriendSending, navigate, openModal]);
 
   const getTargetText = () => {
     if (pathname.includes('/letter/other/sending') || pathname.includes('/letter/anon/sending')) {
@@ -103,6 +123,18 @@ const LetterSendingPage = () => {
         className='-rotate-4 shadow-lg'
       />
       <p className='ty-body3 text-center'>평균 24시간 이내로 편지에 답장을 받아요.</p>
+
+      {/* 편지 전송 성공 Toast (친구/10회 미만) */}
+      {toast && (
+        <div className='fixed bottom-6 left-1/2 -translate-x-1/2 z-[9999]'>
+          <ToastPopup
+            status={toast.status}
+            message={toast.message}
+            visible={visible}
+            onClose={closeToast}
+          />
+        </div>
+      )}
     </div>
   );
 };

--- a/src/stores/modalStore.ts
+++ b/src/stores/modalStore.ts
@@ -6,6 +6,7 @@ export type ModalType =
   | 'friendAdded'
   | 'letterSendingConfirm'
   | 'friendRequest'
+  | 'friendRequestFailed'
   | null;
 
 export type ModalPayload = {
@@ -26,6 +27,9 @@ export type ModalPayload = {
   // friendRequest
   onConfirmFriendRequest?: () => void;
   receiverName?: string;
+
+  // friendRequestFailed
+  onConfirmRequestAgain?: () => void;
 };
 
 interface ModalState {

--- a/src/stores/modalStore.ts
+++ b/src/stores/modalStore.ts
@@ -5,6 +5,7 @@ export type ModalType =
   | 'onboardingSkipConfirm'
   | 'friendAdded'
   | 'letterSendingConfirm'
+  | 'letterSendingFailed'
   | 'friendRequest'
   | 'friendRequestFailed'
   | null;
@@ -23,6 +24,9 @@ export type ModalPayload = {
 
   // letterSendingConfirm
   onConfirmSending?: () => void;
+
+  // letterSendingFailed
+  onConfirmSendingAgain?: () => void;
 
   // friendRequest
   onConfirmFriendRequest?: () => void;


### PR DESCRIPTION
## 📂 관련 이슈

- closes #55 

---

## 🛠️ 작업 사항

- [x] target이 friend 아닐 경우 - 전송 성공 후 토스트 팝업 뜨도록 처리
- [x] target이 friend일 경우 - 1) 10회 미만이라면 토스트 팝업 처리 2) 10회 달성시 sent-transition으로 이동
- [x] 실패 처리를 위한 모달 생성 (친구 신청 실패, 편지 전송 실패)

---

## 📸 관련 이미지 (스크린샷 또는 동영상)

https://github.com/user-attachments/assets/aa8a1a01-c86a-4fd6-8f16-690b3f6a25de

https://github.com/user-attachments/assets/8065665c-49d8-479e-9486-660f0b064bca

---

## 💬 TODO

### 편지 작성 관련 전역 상태 생성 후 실패 처리 가능


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 편지 전송 실패 시 재전송할 수 있는 모달이 추가되었습니다.
  * 친구 요청 실패 시 재시도 옵션을 제공하는 모달이 추가되었습니다.
  * 편지 전송 확인 모달이 반영되어 관련 플로우가 개선되었습니다.
  * 편지 전송 성공 시 화면 하단 토스트로 결과를 안내합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->