### PR TITLE
[fix] 메인 페이지 하단이 탭바에 가려지는 문제 수정

### DIFF
--- a/src/pages/main/Mainpage.tsx
+++ b/src/pages/main/Mainpage.tsx
@@ -59,7 +59,7 @@ const MainPage = () => {
   }
 
   return (
-    <div className='min-h-dvh bg-white'>
+    <div className='min-h-dvh bg-white pb-24'>
       {/* 오늘의 질문 섹션 */}
       <section>
         <QuestionCard


### PR DESCRIPTION
## 📂 관련 이슈

- closes #76 

---

## 🛠️ 작업 사항

- [x] 375 너비에서 화면 하단이 탭바에 가려지지 않도록 패딩 추가

---

## 📸 관련 이미지 (스크린샷 또는 동영상)

<img width="858" height="1340" alt="image" src="https://github.com/user-attachments/assets/5b50c1fe-b065-41e5-a36c-06289ff38cd6" />

---

## 💬 기타 설명

> 💡 추가적으로 공유할 내용이나 리뷰어에게 전달할 사항이 있다면 작성해 주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **스타일**
  * 메인 페이지의 하단 여백을 조정하여 개선된 레이아웃 간격을 제공합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->