### PR TITLE
[Feat] other stop 페이지 구현

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -53,6 +53,7 @@ import LetterPostOtherPage from './pages/letter/LetterPostOtherPage';
 
 import WeeklyReportPage from './pages/WeeklyReportPage';
 import SplashPage from './pages/login/SplashPage';
+import LetterOtherStopPage from './pages/letter/LetterOtherStopPage';
 
 // ===== Placeholders =====
 const TODOPage = () => <div />;
@@ -72,11 +73,11 @@ const router = createBrowserRouter([
           { path: 'letter/inbox-other', element: <LetterInboxOtherPage /> },
           { path: 'letter/inbox-self', element: <LetterInboxSelfPage /> },
           // { path: 'letter/10-end', element: <LetterTenEndPage /> },
-          // { path: 'letter/other-stop', element: <LetterOtherStopPage /> },
+          { path: 'letter/other-stop', element: <LetterOtherStopPage /> },
           { path: 'friend/request', element: <FriendRequestPage /> },
           { path: 'friend/inbox', element: <FriendInboxPage /> },
 
-          { path: 'friend/sent-transition', element: <FriendSentTransitionPage /> },
+          { path: 'friend/sent-transition', element: <FriendSentTransitionPage /> }, // letter/10-end 페이지
           { path: 'report/weekly-report', element: <WeeklyReportPage /> },
         ],
       },

--- a/src/components/modal/ModalRoot.tsx
+++ b/src/components/modal/ModalRoot.tsx
@@ -7,6 +7,7 @@ import LetterSendingConfirmModal from '@/modals/LetterSendingConfirmModal';
 import FriendRequestModal from '@/modals/FriendRequestModal';
 import FriendRequestFailedModal from '@/modals/FriendRequestFailedModal';
 import LetterSendingFailedModal from '@/modals/LetterSendingFailedModal';
+import ConversationRemainingModal from '@/modals/ConversationRemainingModal';
 
 export default function ModalRoot() {
   const { activeModal } = useModalStore();
@@ -32,6 +33,9 @@ export default function ModalRoot() {
 
     case 'friendRequestFailed':
       return <FriendRequestFailedModal />;
+
+    case 'conversationRemaining':
+      return <ConversationRemainingModal />;
 
     default:
       return null;

--- a/src/modals/ConversationRemainingModal.tsx
+++ b/src/modals/ConversationRemainingModal.tsx
@@ -1,0 +1,57 @@
+import ModalFrame from '@/components/modal/ModalFrame';
+import { useModalStore } from '@/stores/modalStore';
+import SadModalIcon from '@/assets/icons/SadModalIcon.svg?react';
+
+export default function ConversationRemainingModal() {
+  const { closeModal, payload } = useModalStore();
+
+  const friendName = payload?.friendName ?? '친구';
+  const remainingCount = typeof payload?.remainingCount === 'number' ? payload.remainingCount : 0;
+
+  const handleContinue = () => {
+    payload?.onContinueConversation?.();
+    closeModal();
+  };
+
+  const handleStop = () => {
+    payload?.onStopConversation?.();
+    closeModal();
+  };
+
+  return (
+    <ModalFrame>
+      <div
+        className='w-[320px] max-w-[92vw] overflow-hidden rounded-xl bg-[#F2F2F2] shadow-[0_30px_80px_rgba(0,0,0,0.55)]'
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className='px-6 py-6 pt-8 text-center flex flex-col items-center justify-center gap-3'>
+          <p className='ty-title3 leading-[28.8px]'>
+            대화가 <span className='text-[#F5544C]'>{remainingCount}회</span> 남았어요.
+            <br />
+            <span>{friendName}</span>님과의 편지를 끝낼까요?
+          </p>
+
+          <SadModalIcon />
+        </div>
+
+        <div className='grid grid-cols-2'>
+          <button
+            type='button'
+            onClick={handleContinue}
+            className='h-14 bg-[#B1B3B4] text-white ty-body3'
+          >
+            이어가기
+          </button>
+
+          <button
+            type='button'
+            onClick={handleStop}
+            className='h-14 bg-[#F5544C] text-white ty-body3'
+          >
+            끝내기
+          </button>
+        </div>
+      </div>
+    </ModalFrame>
+  );
+}

--- a/src/pages/letter/LetterOtherStopPage.tsx
+++ b/src/pages/letter/LetterOtherStopPage.tsx
@@ -1,0 +1,61 @@
+import { Button } from '@/components/common/Button';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
+import LetterEndedEnvelope from '@/assets/icons/LetterEndedEnvelope.svg?react';
+
+type LocationState = {
+  friendName?: string;
+  totalCount?: number; // 7
+  // 필요하면 friendId/threadId/letterId 추가
+  // friendId?: string;
+  // letterId?: string;
+};
+
+export default function OtherStopPage() {
+  const navigate = useNavigate();
+  const { state } = useLocation();
+  const s = (state ?? {}) as LocationState;
+
+  // TODO: 앞 페이지에서 넘겨주는 값으로 교체
+  const receiver = s.friendName ?? '파란수박';
+  const totalCount = typeof s.totalCount === 'number' ? s.totalCount : 7;
+
+  // TODO: 실제 식별자 있으면 교체
+  const letterId = '1';
+
+  const handleGoToReview = () => {
+    navigate(`/letter/review/${letterId}`);
+  };
+
+  return (
+    <div className='min-h-dvh px-6 pt-14 pb-28'>
+      {/* Header */}
+      <header className='flex flex-col justify-start gap-2'>
+        <p className='ty-body1 leading-tight'>
+          {receiver}님과 <span className='text-[var(--color-primary-500)]'>{totalCount}회</span>
+          의 대화를
+          <br />
+          나누었어요.
+        </p>
+      </header>
+
+      {/* Envelope + Link */}
+      <section className='mt-15 flex flex-col items-center'>
+        <LetterEndedEnvelope className='block' />
+        <Link
+          to={`/friend/post/${letterId}`}
+          className='ty-body5 text-(--color-text-assistive) mt-3 underline underline-offset-4'
+        >
+          우리가 나눴던 대화 다시보기
+        </Link>
+      </section>
+
+      <section className='flex flex-col items-center'>
+        <div className='mt-[45px] w-full flex flex-col items-center gap-3'>
+          <Button className='w-[343px]' onClick={handleGoToReview}>
+            후기 남기기
+          </Button>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/pages/letter/LetterReplyPage.tsx
+++ b/src/pages/letter/LetterReplyPage.tsx
@@ -1,8 +1,9 @@
 import { useMemo } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
 import BackHeader from '@/components/common/headers/BackHeader';
 import { Button } from '@/components/common/Button';
+import { useModalStore } from '@/stores/modalStore';
 
 type ReplyViewData = {
   senderName: string;
@@ -13,7 +14,7 @@ type ReplyViewData = {
 
 export default function LetterReplyPage() {
   const navigate = useNavigate();
-  const params = useParams();
+  const { openModal } = useModalStore();
 
   // 필요하면 라우트에서 letterId/threadId를 받아와서 API 연결
   // const letterId = params.letterId;
@@ -44,7 +45,19 @@ export default function LetterReplyPage() {
   };
 
   const handleEnd = () => {
-    navigate(-1); // TODO: 여기 뒤로가기가 아니라 모달 떠야함. 모달 구현 필요
+    openModal('conversationRemaining', {
+      friendName: '파란수박',
+      remainingCount: 4,
+      onContinueConversation: () => {
+        // 그냥 닫히고 계속 작성
+      },
+      onStopConversation: () => {
+        // other-stop 페이지로 이동
+        navigate('/letter/other-stop', {
+          state: { friendName: '파란수박', totalCount: 7 },
+        });
+      },
+    });
   };
 
   return (

--- a/src/stores/modalStore.ts
+++ b/src/stores/modalStore.ts
@@ -8,6 +8,7 @@ export type ModalType =
   | 'letterSendingFailed'
   | 'friendRequest'
   | 'friendRequestFailed'
+  | 'conversationRemaining'
   | null;
 
 export type ModalPayload = {
@@ -35,6 +36,11 @@ export type ModalPayload = {
 
   // friendRequestFailed
   onConfirmRequestAgain?: () => void;
+
+  // conversationRemaining (대화 n회 남음)
+  remainingCount?: number;
+  onContinueConversation?: () => void;
+  onStopConversation?: () => void;
 };
 
 interface ModalState {


### PR DESCRIPTION
## 📂 관련 이슈

- closes #102 

---

## 🛠️ 작업 사항

- [x] /letter/other-stop 라우팅 설정
- [x] 모달 스토어/루트에 새로운 모달(conversationRemaining) 추가
- [x] 대화 끝내기 모달 구현 및 연결
- [x] 편지함 대화 끝내기 페이지 구현

---

## 📸 관련 이미지 (스크린샷 또는 동영상)

https://github.com/user-attachments/assets/cd8bda78-6ba8-4963-a670-8d11648aae84



---

## 💬 기타 설명

> 💡 letter/other-stop sent-transition 페이지 편지지 모양을 색상+우표 로 수정 필요. 현재는 연결이 우선이라 TODO로 남겨두었습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 대화 종료 시 남은 대화 건수를 표시하는 모달 추가
* 대화를 계속하거나 종료하기 선택 옵션 제공
* 새로운 대화 종료 화면 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->