### PR TITLE
[Feat] 친구 스레드 연동 및 친구에게 편지 보내기

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -58,6 +58,7 @@ import SplashPage from './pages/login/SplashPage';
 import LetterOtherStopPage from './pages/letter/LetterOtherStopPage';
 import GuestGate from './routes/GuestGate';
 import EntryRoute from './routes/EntryRoute';
+import FriendReplyPage from './pages/friend/FriendReplyPage';
 
 // ===== Placeholders =====
 const TODOPage = () => <div />;
@@ -169,10 +170,11 @@ const router = createBrowserRouter([
               { path: 'letter/self_draft', element: <Navigate to='/letter/self/draft' replace /> },
               { path: 'friend/draft', element: <FriendDraftPage /> }, // 기존 라우팅
               { path: 'friend/thread/:friendId', element: <FriendPostPage /> }, // 나눈 편지 목록(질문 스레드 단위)
-              { path: 'friend/thread/:threadId/draft', element: <FriendDraftPage /> }, // 작성 버튼 눌렀을 때, 새 편지 작성
+              // { path: 'friend/thread/:threadId/draft', element: <FriendDraftPage /> }, // 작성 버튼 눌렀을 때, 새 편지 작성
+              // => TODO : 이 부분은 그냥 /friend/draft로 들어가도 되지 않나요? 어차피 thread의 경우 시간 순으로 나열되는데? 친구에 대한 정보는 가지고 있습니다.
               {
-                path: 'friend/:friendId/thread/:threadId/letters/:letterId',
-                element: <LetterReplyPage />,
+                path: 'friend/thread/:friendId/:letterId',
+                element: <FriendReplyPage />,
               },
               { path: 'report/keyword-letter', element: <TODOPage /> },
               { path: 'report/keyword-letter-indi', element: <TODOPage /> },

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -94,7 +94,7 @@ const router = createBrowserRouter([
                   { index: true, element: <Navigate to='/friend/inbox' replace /> },
                   { path: 'inbox', element: <FriendInboxPage /> },
                   { path: 'request', element: <FriendRequestPage /> },
-                  { path: 'sent-transition', element: <FriendSentTransitionPage /> }, // letter/10-end 페이지
+                  { path: 'sent-transition/:threadId', element: <FriendSentTransitionPage /> }, // letter/10-end 페이지
                 ],
               },
               { path: 'report/weekly-report', element: <WeeklyReportPage /> },
@@ -156,10 +156,10 @@ const router = createBrowserRouter([
                 ],
               },
               { path: 'letter/thread/:threadId', element: <LetterPostOtherPage /> },
-              { path: 'letter/reply/:letterId', element: <LetterReplyPage /> }, // TODO : 예디) 이 주소는 뭔가요?
+              // { path: 'letter/reply/:letterId', element: <LetterReplyPage /> }, // TODO : 예디) 이 주소는 뭔가요?
               { path: 'letter/reply/:threadId/:letterId', element: <LetterReplyPage /> },
               { path: 'letter/report', element: <LetterReportPage /> },
-              { path: 'letter/review/:letterId', element: <LetterReviewPage /> },
+              { path: 'letter/review/:threadId', element: <LetterReviewPage /> },
               { path: 'letter/post-self/:letterId', element: <LetterPostSelfPage /> },
               { path: 'letter/loading', element: <LoadingPage /> },
               // 기존 코드 충돌 방지를 위한 코드(레거시). 추후 삭제

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -85,8 +85,6 @@ const router = createBrowserRouter([
                   { path: 'inbox-self', element: <LetterInboxSelfPage /> },
                 ],
               },
-              // { path: 'letter/inbox-other', element: <LetterInboxOtherPage /> }, // letter/inbox-self에서도 탭바 활성화 되도록
-              // { path: 'letter/inbox-self', element: <LetterInboxSelfPage /> },
               // { path: 'letter/10-end', element: <LetterTenEndPage /> },
               { path: 'letter/other-stop', element: <LetterOtherStopPage /> },
               { path: 'friend/request', element: <FriendRequestPage /> },
@@ -147,7 +145,6 @@ const router = createBrowserRouter([
                   { path: 'draft', element: <LetterDraftRoute /> },
                   { path: 'decorate', element: <LetterDecoPage /> },
                   { path: 'sending', element: <LetterSendingPage /> },
-                  // { path: 'sent-transition', element: <LetterSendingPage /> }, TODO: 예디랑 논의 필요
                 ],
               },
               { path: 'letter/thread/:threadId', element: <LetterPostOtherPage /> },
@@ -155,7 +152,6 @@ const router = createBrowserRouter([
               { path: 'letter/reply/:threadId/:letterId', element: <LetterReplyPage /> },
               { path: 'letter/report', element: <LetterReportPage /> },
               { path: 'letter/review/:letterId', element: <LetterReviewPage /> },
-              // { path: 'letter/post-self', element: <LetterPostSelfPage /> }, // TODO : 미사용 라우터 삭제
               { path: 'letter/post-self/:letterId', element: <LetterPostSelfPage /> },
               { path: 'letter/loading', element: <LoadingPage /> },
               // 기존 코드 충돌 방지를 위한 코드(레거시). 추후 삭제
@@ -237,26 +233,6 @@ const router = createBrowserRouter([
 
           // 404 처리
           { path: '*', element: <NotFoundPage /> },
-
-          // 기존 코드. 주석처리
-          // {
-          // path: 'letter/anon-draft',
-          // element: <AnonDraftPage />,
-          // },
-          // {
-          // path: 'letter/other-draft',
-          // element: <OtherDraftPage />,
-          // },
-          // {
-          // path: 'letter/self-draft',
-          // element: <SelfDraftPage />,
-          // },
-          // {
-          // path: 'letter/:mode-decorate',
-          // element: <LetterDecoPage />,
-          // },
-
-          // { path: 'letter/report', element: <LetterReportPage /> },
         ],
       },
     ],

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -168,7 +168,7 @@ const router = createBrowserRouter([
               },
               { path: 'letter/self_draft', element: <Navigate to='/letter/self/draft' replace /> },
               { path: 'friend/draft', element: <FriendDraftPage /> }, // 기존 라우팅
-              { path: 'friend/thread/:threadId', element: <FriendPostPage /> }, // 나눈 편지 목록(질문 스레드 단위)
+              { path: 'friend/thread/:friendId', element: <FriendPostPage /> }, // 나눈 편지 목록(질문 스레드 단위)
               { path: 'friend/thread/:threadId/draft', element: <FriendDraftPage /> }, // 작성 버튼 눌렀을 때, 새 편지 작성
               {
                 path: 'friend/:friendId/thread/:threadId/letters/:letterId',

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -168,9 +168,8 @@ const router = createBrowserRouter([
               },
               { path: 'letter/self_draft', element: <Navigate to='/letter/self/draft' replace /> },
               { path: 'friend/draft', element: <FriendDraftPage /> }, // 기존 라우팅
-              { path: 'friend/post/:letterId', element: <FriendPostPage /> }, // 기존 라우팅
-              { path: 'friend/:friendId/thread/:threadId', element: <FriendPostPage /> }, // 나눈 편지 목록(질문 스레드 단위)
-              { path: 'friend/:friendId/thread/:threadId/draft', element: <FriendDraftPage /> }, // 작성 버튼 눌렀을 때, 새 편지 작성
+              { path: 'friend/thread/:threadId', element: <FriendPostPage /> }, // 나눈 편지 목록(질문 스레드 단위)
+              { path: 'friend/thread/:threadId/draft', element: <FriendDraftPage /> }, // 작성 버튼 눌렀을 때, 새 편지 작성
               {
                 path: 'friend/:friendId/thread/:threadId/letters/:letterId',
                 element: <LetterReplyPage />,

--- a/src/api/mails/friendThread.ts
+++ b/src/api/mails/friendThread.ts
@@ -1,0 +1,18 @@
+import { axiosInstance } from '@/api/axios';
+import type { ApiError } from '@/types/dto/common';
+import type { FriendThreadResponse, FriendThreadSuccess } from '@/types/dto/mails/friendThread';
+
+export async function getFriendThread(friendId: number): Promise<FriendThreadSuccess> {
+  const { data } = await axiosInstance.get<FriendThreadResponse>(
+    `/mailbox/friends/threads/${friendId}/letters`,
+  );
+
+  if (data.resultType !== 'SUCCESS' || !data.success) {
+    throw {
+      errorCode: data.error?.errorCode ?? 'FRIEND_THREAD',
+      reason: data.error?.reason ?? '친구와의 대화를 불러오지 못했어요. 잠시 후 다시 시도해주세요.',
+      data: data.error?.data ?? {},
+    } satisfies ApiError;
+  }
+  return data.success;
+}

--- a/src/components/letters/DailyQuestionBox.tsx
+++ b/src/components/letters/DailyQuestionBox.tsx
@@ -20,13 +20,17 @@ const DailyQuestionBox = ({
 
   return (
     <>
-      <div className='flex items-center gap-2'>
-        <button type='button' className='flex items-center' onClick={() => setIsClicked((v) => !v)}>
+      <div className='flex items-center'>
+        <button
+          type='button'
+          className='flex items-center gap-2'
+          onClick={() => setIsClicked((v) => !v)}
+        >
           <Icon className={iconClassName} />
+          <span className='ty-detail text-[var(--color-text-assistive)]'>
+            오늘의 질문이 궁금하다면?
+          </span>
         </button>
-        <span className='ty-detail text-[var(--color-text-assistive)]'>
-          오늘의 질문이 궁금하다면?
-        </span>
       </div>
 
       <div

--- a/src/hooks/friend/useFriendThread.ts
+++ b/src/hooks/friend/useFriendThread.ts
@@ -1,0 +1,11 @@
+import { getFriendThread } from '@/api/mails/friendThread';
+import { useQuery } from '@tanstack/react-query';
+
+export function useFriendThread(friendId: number) {
+  return useQuery({
+    queryKey: ['friend-thread', friendId],
+    queryFn: () => getFriendThread(friendId),
+    enabled: Number.isFinite(friendId) && friendId > 0,
+    retry: false,
+  });
+}

--- a/src/hooks/letters/useDailyQuestion.ts
+++ b/src/hooks/letters/useDailyQuestion.ts
@@ -1,14 +1,14 @@
 import { useQuery } from '@tanstack/react-query';
 import { getDailyQuestion } from '@/api/question';
-
-const todayKST = new Intl.DateTimeFormat('sv-SE', {
-  timeZone: 'Asia/Seoul',
-}).format(new Date());
+import { getNowKSTIsoString } from '@/utils/date';
+import { useMemo } from 'react';
 
 export function useDailyQuestion() {
+  const nowKstIso = useMemo(() => getNowKSTIsoString(), []);
+
   return useQuery({
-    queryKey: ['daily-question', todayKST],
-    queryFn: () => getDailyQuestion(todayKST),
+    queryKey: ['daily-question'],
+    queryFn: () => getDailyQuestion(nowKstIso),
     retry: false,
   });
 }

--- a/src/hooks/letters/useDailyQuestion.ts
+++ b/src/hooks/letters/useDailyQuestion.ts
@@ -1,13 +1,14 @@
 import { useQuery } from '@tanstack/react-query';
 import { getDailyQuestion } from '@/api/question';
-import { getNowKSTIsoString } from '@/utils/date';
+import { getNowKSTIsoString, getTodayKstKey } from '@/utils/date';
 import { useMemo } from 'react';
 
 export function useDailyQuestion() {
   const nowKstIso = useMemo(() => getNowKSTIsoString(), []);
+  const todayKstKey = useMemo(() => getTodayKstKey(), []); // "YYYY-MM-DD"
 
   return useQuery({
-    queryKey: ['daily-question'],
+    queryKey: ['daily-question', todayKstKey],
     queryFn: () => getDailyQuestion(nowKstIso),
     retry: false,
   });

--- a/src/modals/LetterSendingConfirmModal.tsx
+++ b/src/modals/LetterSendingConfirmModal.tsx
@@ -2,12 +2,14 @@ import ModalFrame from '@/components/modal/ModalFrame';
 import { useModalStore } from '@/stores/modalStore';
 import HappyModalIcon from '@/assets/icons/HappyModalIcon.svg?react';
 import { useLocation } from 'react-router-dom';
+import { useThreadFlowStore } from '@/stores/letterContext';
 
 export default function LetterSendingConfirmModal() {
   const { closeModal, payload } = useModalStore();
   const { pathname } = useLocation();
-
   const friendName = payload?.friendName;
+
+  const senderName = useThreadFlowStore((s) => s.senderName);
 
   const handleStay = () => {
     payload?.onConfirmCancelSending?.();
@@ -22,7 +24,7 @@ export default function LetterSendingConfirmModal() {
   const getTargetText = () => {
     // TODO : 추후 라이팅 주소 확인 필요
     if (pathname.includes('/letter/other/decorate') || pathname.includes('/letter/anon/decorate'))
-      return '익명 편지를';
+      return `${senderName}님에게 편지를`;
     if (pathname.includes('/letter/self/decorate')) return '미래의 나에게 편지를';
     if (pathname.includes('/letter/friend/decorate')) return `${friendName}님에게 편지를`;
     return '편지를';

--- a/src/modals/LetterSendingConfirmModal.tsx
+++ b/src/modals/LetterSendingConfirmModal.tsx
@@ -7,6 +7,8 @@ export default function LetterSendingConfirmModal() {
   const { closeModal, payload } = useModalStore();
   const { pathname } = useLocation();
 
+  const friendName = payload?.friendName;
+
   const handleStay = () => {
     payload?.onConfirmCancelSending?.();
     closeModal();
@@ -22,7 +24,7 @@ export default function LetterSendingConfirmModal() {
     if (pathname.includes('/letter/other/decorate') || pathname.includes('/letter/anon/decorate'))
       return '익명 편지를';
     if (pathname.includes('/letter/self/decorate')) return '미래의 나에게 편지를';
-    if (pathname.includes('/letter/friend/decorate')) return '친구에게 편지를';
+    if (pathname.includes('/letter/friend/decorate')) return `${friendName}님에게 편지를`;
     return '편지를';
   };
 

--- a/src/pages/friend/FriendDraftPage.tsx
+++ b/src/pages/friend/FriendDraftPage.tsx
@@ -35,7 +35,7 @@ export default function FriendDraftPage() {
   }, [setActiveTarget]);
 
   const location = useLocation();
-  const friendName = (location.state as { friendName?: string } | null)?.friendName ?? '친구';
+  const friendName = (location.state as { friendName?: string })?.friendName;
 
   const validate = (title: string, content: string) => {
     if (title.length < LIMIT.TITLE.MIN) return `제목을 ${LIMIT.TITLE.MIN}자 이상 입력해주세요.`;

--- a/src/pages/friend/FriendDraftPage.tsx
+++ b/src/pages/friend/FriendDraftPage.tsx
@@ -12,11 +12,7 @@ import { useDailyQuestion } from '@/hooks/letters/useDailyQuestion';
 import { useGlobalToast } from '@/components/toast/ToastProvider';
 import LoadingPage from '../system/LoadingPage';
 import { Button } from '@/components/common/Button';
-
-const LIMIT = {
-  TITLE: { MIN: 3, MAX: 20 },
-  CONTENT: { MIN: 1, MAX: 500 },
-} as const;
+import { validateLetter } from '@/utils/validateLetter';
 
 export default function FriendDraftPage() {
   const { data, isLoading, isError, refetch } = useDailyQuestion();
@@ -36,17 +32,6 @@ export default function FriendDraftPage() {
 
   const location = useLocation();
   const friendName = (location.state as { friendName?: string })?.friendName;
-
-  const validate = (title: string, content: string) => {
-    if (title.length < LIMIT.TITLE.MIN) return `제목을 ${LIMIT.TITLE.MIN}자 이상 입력해주세요.`;
-    if (title.length > LIMIT.TITLE.MAX)
-      return `제목은 최대 ${LIMIT.TITLE.MAX}자까지 입력할 수 있어요.`;
-    if (content.length < LIMIT.CONTENT.MIN) return '내용을 작성해 주세요!';
-    if (content.length > LIMIT.CONTENT.MAX)
-      return `내용은 최대 ${LIMIT.CONTENT.MAX}자까지 입력할 수 있어요.`;
-
-    return null;
-  };
 
   // questionId 저장
   useEffect(() => {
@@ -72,7 +57,7 @@ export default function FriendDraftPage() {
 
     const title = draft.title.trim();
     const content = draft.content.trim();
-    const errorMsg = validate(title, content);
+    const errorMsg = validateLetter(title, content);
 
     if (errorMsg) {
       showToast(errorMsg, 'error');

--- a/src/pages/friend/FriendDraftPage.tsx
+++ b/src/pages/friend/FriendDraftPage.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useMemo, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useEffect } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 import BackHeader from '@/components/common/headers/BackHeader';
 import ToggleSwitch from '@/components/common/ToggleSwitch';
@@ -8,45 +8,108 @@ import { BsQuestionCircle } from 'react-icons/bs';
 import LetterTextBox from '@/components/letters/LetterTextBox';
 import DailyQuestionBox from '@/components/letters/DailyQuestionBox';
 import { useLetterStore } from '@/stores/letterStore';
+import { useDailyQuestion } from '@/hooks/letters/useDailyQuestion';
+import { useGlobalToast } from '@/components/toast/ToastProvider';
+import LoadingPage from '../system/LoadingPage';
+import { Button } from '@/components/common/Button';
+
+const LIMIT = {
+  TITLE: { MIN: 3, MAX: 20 },
+  CONTENT: { MIN: 1, MAX: 500 },
+} as const;
 
 export default function FriendDraftPage() {
-  const navigate = useNavigate();
+  const { data, isLoading, isError, refetch } = useDailyQuestion();
 
   const setActiveTarget = useLetterStore((s) => s.setActiveTarget);
   const draft = useLetterStore((s) => s.getDraft());
   const patchDraft = useLetterStore((s) => s.patchDraft);
+  const resetCurrent = useLetterStore((s) => s.resetCurrent);
+
+  const { showToast } = useGlobalToast();
+  const navigate = useNavigate();
 
   // 페이지 진입 시 target 세팅
   useEffect(() => {
     setActiveTarget('friend');
   }, [setActiveTarget]);
 
-  // TODO : friendId는 추후 닉네임 불러올 때 Id로 가져올 거라서 연동 후 사용
-  // const params = useParams();
-  // const friendId = params.friendId ?? '1';
+  const location = useLocation();
+  const friendName = (location.state as { friendName?: string } | null)?.friendName ?? '친구';
 
-  // TODO: friendName은 실제 데이터로 교체
-  const friendName = useMemo(() => '파란수박', []);
-  const dailyQuestion = useMemo(() => '당신의 인생에 큰 영감을 주는 사람은 누구인가요?', []);
+  const validate = (title: string, content: string) => {
+    if (title.length < LIMIT.TITLE.MIN) return `제목을 ${LIMIT.TITLE.MIN}자 이상 입력해주세요.`;
+    if (title.length > LIMIT.TITLE.MAX)
+      return `제목은 최대 ${LIMIT.TITLE.MAX}자까지 입력할 수 있어요.`;
+    if (content.length < LIMIT.CONTENT.MIN) return '내용을 작성해 주세요!';
+    if (content.length > LIMIT.CONTENT.MAX)
+      return `내용은 최대 ${LIMIT.CONTENT.MAX}자까지 입력할 수 있어요.`;
 
-  const [letter, setLetter] = useState({
-    title: '',
-    content: '',
-  });
-  const [isPublic, setIsPublic] = useState(false);
+    return null;
+  };
+
+  // questionId 저장
+  useEffect(() => {
+    const newId = data?.id;
+    if (!newId) return;
+
+    if (draft.questionId !== newId) {
+      patchDraft({ questionId: newId });
+    }
+  }, [data?.id, draft.questionId, patchDraft]);
 
   const handleSubmit = () => {
-    // TODO:
-    // 1. title 최소/최대 글자 수 조건 확인
-    // 2. content 최소/최대 글자 수 조건 확인
-    // 3. 조건 안 맞으면 토스트/에러 처리
+    if (isLoading) {
+      showToast('질문을 불러오는 중이에요. 잠시만 기다려주세요.', 'error');
+      return;
+    }
+
+    const questionId = data?.id;
+    if (isError || !questionId) {
+      showToast('질문을 불러오지 못했어요. 다시 시도해주세요.', 'error');
+      return;
+    }
+
+    const title = draft.title.trim();
+    const content = draft.content.trim();
+    const errorMsg = validate(title, content);
+
+    if (errorMsg) {
+      showToast(errorMsg, 'error');
+      return;
+    }
+
+    patchDraft({ questionId });
+
     navigate('/letter/friend/decorate', {
-      state: {
-        title: letter.title,
-        content: letter.content,
-      },
+      state: { friendName },
     });
   };
+
+  const handleBack = () => {
+    resetCurrent();
+    navigate(-1);
+  };
+
+  const formattedQuestionText = (data?.content ?? '').replace(/^질문\s*#\d+:\s*/, '');
+
+  if (isLoading) {
+    return <LoadingPage />;
+  }
+
+  if (isError) {
+    return (
+      <div className='min-h-dvh bg-[var(--color-bg-500)]'>
+        <BackHeader title={`${friendName}에게 보내는 편지`} onBack={handleBack} />
+        <div className='flex flex-col items-center justify-center gap-8 py-30 text-center px-5'>
+          <p className='ty-title3'>질문을 불러오지 못했어요.</p>
+          <Button type='button' onClick={() => refetch()} className='w-full max-w-[240px]'>
+            다시 시도
+          </Button>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className='flex flex-col'>
@@ -57,22 +120,30 @@ export default function FriendDraftPage() {
             꾸미기
           </button>
         }
+        onBack={handleBack}
       />
       <div className='flex flex-col items-start p-5 -mt-3 gap-3'>
         <DailyQuestionBox
-          question={dailyQuestion}
+          question={formattedQuestionText}
           Icon={BsQuestionCircle}
           iconClassName='text-(--color-text-assistive)'
           bubbleBgColor='#414141'
-          bubbleTextStyle='var(--color-white)' // css 문법에 따라 var(--color-...) 형식으로 props 넘겨야 함
+          bubbleTextStyle='var(--color-white)'
         />
       </div>
       <div className='px-4'>
-        <LetterTextBox value={letter} onChange={setLetter} className='w-[343px] h-[394px]' />
+        <LetterTextBox
+          value={{ title: draft.title, content: draft.content }}
+          onChange={(next) => patchDraft(next)}
+          className='w-[343px] h-[394px]'
+        />{' '}
       </div>
       <div className='flex items-center justify-end p-5 -mt-5 gap-2'>
         <span className='ty-body5 text-(--color-text-normal)'>오늘 하루 동안 편지 공개하기</span>
-        <ToggleSwitch checked={isPublic} onCheckedChange={setIsPublic} />
+        <ToggleSwitch
+          checked={draft.isPublic}
+          onCheckedChange={(v) => patchDraft({ isPublic: v })}
+        />
       </div>
       <p className='flex p-5 -mt-3 ty-detailMedium text-(--color-text-assistive)'>
         비방의 언어가 담기면 자동으로 필터링 돼요.

--- a/src/pages/friend/FriendInboxPage.tsx
+++ b/src/pages/friend/FriendInboxPage.tsx
@@ -6,12 +6,16 @@ import FriendTopTabs from '@/components/FriendTopTabs';
 import { AiOutlineSearch } from 'react-icons/ai';
 import SortIcon from '@/assets/icons/SortIcon.svg?react';
 import { useFriends } from '@/hooks/friend/useFriend';
+import { ENVELOPE_ASSET_MAP } from '@/constants/envelopeAssets';
 
 type FriendInboxItem = {
   id: number;
   name: string;
   exchangeCount: number;
   lastDate: string; // '2026.1.3'
+  paperId: number;
+  stampId: number;
+  stampUrl: string;
 };
 
 type SortOrder = 'latest' | 'oldest';
@@ -36,6 +40,9 @@ export default function FriendInboxPage() {
         name: f.nickname,
         exchangeCount: f.letterCount,
         lastDate: f.recentLetter.createdAt.split('T')[0].replaceAll('-', '.'),
+        paperId: Number(f.recentLetter.design.paper?.id ?? 0), // TODO : 백엔드 필드 수정 예정, DTO 수정 필요
+        stampId: Number(f.recentLetter.design.stamp?.id ?? 0), // TODO : 백엔드 필드 수정 예정, DTO 수정 필요
+        stampUrl: f.recentLetter.design.stamp?.assetUrl,
       })),
     [friends],
   );
@@ -95,29 +102,55 @@ export default function FriendInboxPage() {
         <div className='mt-4 space-y-4'>
           {isLoading && <div className='text-sm text-gray-400'>불러오는 중...</div>}
           {!isLoading &&
-            filtered.map((f) => (
-              <button
-                key={f.id}
-                type='button'
-                onClick={() => navigate(`/friend/${f.id}/posts`)} // TODO 여기 유저 id 생기면 수정
-                className='w-[343px] h-[144px] rounded-xl bg-white p-4 text-left shadow-[0_8px_24px_rgba(0,0,0,0.06)]'
-              >
-                <div className='flex items-center justify-between gap-3'>
-                  <div className='flex items-center gap-3'>
-                    <div className='h-10 w-10 rounded-full bg-[#EDEDED]' />
-                    <div>
-                      <p className='ty-body2'>{f.name}</p>
-                      <p className='mt-1 ty-detailMedium'>편지를 나눈 횟수 {f.exchangeCount}회</p>
+            filtered.map((f) => {
+              const envelopeAsset = ENVELOPE_ASSET_MAP[f.paperId];
+              const EnvelopePreview = envelopeAsset?.Preview;
+
+              return (
+                <button
+                  key={f.id}
+                  type='button'
+                  onClick={() => navigate(`/friend/${f.id}/posts`)}
+                  className='w-[343px] h-[144px] rounded-xl bg-white p-4 text-left shadow-[0_8px_24px_rgba(0,0,0,0.06)]'
+                >
+                  {/* 상단: 프로필 + 봉투 */}
+                  <div className='flex items-center justify-between gap-3'>
+                    <div className='flex flex-col items-start gap-3'>
+                      {/* 프로필 사진 */}
+                      <div className='h-10 w-10 rounded-full bg-[#EDEDED]' />
+                      <div>
+                        <p className='ty-body2'>{f.name}</p>
+                        <p className='mt-1 ty-detailMedium'>편지를 나눈 횟수 {f.exchangeCount}회</p>
+                      </div>
+                    </div>
+
+                    {/* 오른쪽: 봉투 + 스탬프 + 날짜 */}
+                    <div className='flex flex-col gap-2 mt-2'>
+                      <div className='relative h-23 w-25 shrink-0 flex items-center justify-center -mt-3'>
+                        {EnvelopePreview ? (
+                          <EnvelopePreview className='h-full w-full' />
+                        ) : (
+                          <div className='h-full w-full rounded-xl bg-[#F2F2F2]' />
+                        )}
+
+                        {f.stampUrl ? (
+                          <img
+                            src={f.stampUrl}
+                            alt=''
+                            className='absolute right-1 bottom-3 h-7 w-7 object-contain'
+                            draggable={false}
+                          />
+                        ) : null}
+                      </div>
+
+                      <div className='flex justify-end pr-2 ty-detailMedium text-[var(--color-text-normal)]'>
+                        {f.lastDate}
+                      </div>
                     </div>
                   </div>
-
-                  {/* 봉투 썸네일 자리(나중에 이미지로 교체) */}
-                  <div className='h-12 w-16 rounded-xl bg-[#F2F2F2]' />
-                </div>
-
-                <div className='mt-3 flex justify-end ty-detailMedium'>{f.lastDate}</div>
-              </button>
-            ))}
+                </button>
+              );
+            })}
 
           {isEmptyFriends && (
             <div className='mt-8 px-4 py-10 text-center ty-body3 text-[var(--color-text-assistive)]'>

--- a/src/pages/friend/FriendInboxPage.tsx
+++ b/src/pages/friend/FriendInboxPage.tsx
@@ -35,7 +35,7 @@ export default function FriendInboxPage() {
         id: f.friendUserId,
         name: f.nickname,
         exchangeCount: f.letterCount,
-        lastDate: f.createdAt.split('T')[0].replaceAll('-', '.'),
+        lastDate: f.recentLetter.createdAt.split('T')[0].replaceAll('-', '.'),
       })),
     [friends],
   );

--- a/src/pages/friend/FriendInboxPage.tsx
+++ b/src/pages/friend/FriendInboxPage.tsx
@@ -37,7 +37,7 @@ export default function FriendInboxPage() {
   const items = useMemo<FriendInboxItem[]>(
     () =>
       friends.map((f) => ({
-        id: f.id, // id는 threadId의 역할을 합니다.
+        id: f.id,
         friendUserId: f.friendUserId,
         name: f.nickname,
         exchangeCount: f.letterCount,

--- a/src/pages/friend/FriendInboxPage.tsx
+++ b/src/pages/friend/FriendInboxPage.tsx
@@ -41,10 +41,12 @@ export default function FriendInboxPage() {
         friendUserId: f.friendUserId,
         name: f.nickname,
         exchangeCount: f.letterCount,
-        lastDate: f.recentLetter.createdAt.split('T')[0].replaceAll('-', '.'),
-        paperId: Number(f.recentLetter.design.paper?.id ?? 0), // TODO : 백엔드 필드 수정 예정, DTO 수정 필요
-        stampId: Number(f.recentLetter.design.stamp?.id ?? 0), // TODO : 백엔드 필드 수정 예정, DTO 수정 필요
-        stampUrl: f.recentLetter.design.stamp?.assetUrl,
+        lastDate: f.recentLetter?.createdAt
+          ? f.recentLetter.createdAt.split('T')[0].replaceAll('-', '.')
+          : '-',
+        paperId: Number(f.recentLetter?.design.paper?.id ?? 0), // TODO : 백엔드 필드 수정 예정, DTO 수정 필요
+        stampId: Number(f.recentLetter?.design.stamp?.id ?? 0), // TODO : 백엔드 필드 수정 예정, DTO 수정 필요
+        stampUrl: (f.recentLetter?.design?.stamp?.assetUrl ?? '').trim(),
       })),
     [friends],
   );

--- a/src/pages/friend/FriendInboxPage.tsx
+++ b/src/pages/friend/FriendInboxPage.tsx
@@ -50,8 +50,8 @@ export default function FriendInboxPage() {
   );
 
   const handleOpenThread = (item: FriendInboxItem) => {
-    navigate(`/friend/thread/${item.id}`, {
-      state: { friendUserId: item.friendUserId, friendName: item.name },
+    navigate(`/friend/thread/${item.friendUserId}`, {
+      state: { friendId: item.friendUserId, friendName: item.name },
     });
   };
 

--- a/src/pages/friend/FriendInboxPage.tsx
+++ b/src/pages/friend/FriendInboxPage.tsx
@@ -44,7 +44,7 @@ export default function FriendInboxPage() {
         lastDate: f.recentLetter?.createdAt
           ? f.recentLetter.createdAt.split('T')[0].replaceAll('-', '.')
           : '-',
-        paperId: Number(f.recentLetter?.design.paper?.id ?? 0), // TODO : 백엔드 필드 수정 예정, DTO 수정 필요
+        paperId: Number((f.recentLetter?.design.paper?.id ?? 0) + 1),
         stampId: Number(f.recentLetter?.design.stamp?.id ?? 0), // TODO : 백엔드 필드 수정 예정, DTO 수정 필요
         stampUrl: (f.recentLetter?.design?.stamp?.assetUrl ?? '').trim(),
       })),

--- a/src/pages/friend/FriendInboxPage.tsx
+++ b/src/pages/friend/FriendInboxPage.tsx
@@ -10,6 +10,7 @@ import { ENVELOPE_ASSET_MAP } from '@/constants/envelopeAssets';
 
 type FriendInboxItem = {
   id: number;
+  friendUserId: number;
   name: string;
   exchangeCount: number;
   lastDate: string; // '2026.1.3'
@@ -36,7 +37,8 @@ export default function FriendInboxPage() {
   const items = useMemo<FriendInboxItem[]>(
     () =>
       friends.map((f) => ({
-        id: f.friendUserId,
+        id: f.id, // id는 threadId의 역할을 합니다.
+        friendUserId: f.friendUserId,
         name: f.nickname,
         exchangeCount: f.letterCount,
         lastDate: f.recentLetter.createdAt.split('T')[0].replaceAll('-', '.'),
@@ -46,6 +48,12 @@ export default function FriendInboxPage() {
       })),
     [friends],
   );
+
+  const handleOpenThread = (item: FriendInboxItem) => {
+    navigate(`/friend/thread/${item.id}`, {
+      state: { friendUserId: item.friendUserId, friendName: item.name },
+    });
+  };
 
   const filtered = useMemo(() => {
     const k = keyword.trim();
@@ -110,7 +118,7 @@ export default function FriendInboxPage() {
                 <button
                   key={f.id}
                   type='button'
-                  onClick={() => navigate(`/friend/${f.id}/posts`)}
+                  onClick={() => handleOpenThread(f)}
                   className='w-[343px] h-[144px] rounded-xl bg-white p-4 text-left shadow-[0_8px_24px_rgba(0,0,0,0.06)]'
                 >
                   {/* 상단: 프로필 + 봉투 */}

--- a/src/pages/friend/FriendPostPage.tsx
+++ b/src/pages/friend/FriendPostPage.tsx
@@ -18,64 +18,6 @@ type PostItem = {
 export default function FriendPostPage() {
   const navigate = useNavigate();
   const params = useParams();
-  const friendId = params.friendId ?? '1';
-
-  const friendName = '파란수박';
-
-  const posts = useMemo<PostItem[]>(() => {
-    const data: PostItem[] = [
-      {
-        id: 1,
-        title: '이지영선생님러브러브...',
-        dateText: '2026.1.3',
-        sentAt: '2026-01-03T09:10:00',
-        direction: 'received',
-        colorKey: 'yellow',
-      },
-      {
-        id: 2,
-        title: '나는현우진이좋은데...',
-        dateText: '2026.1.3',
-        sentAt: '2026-01-03T09:18:00',
-        direction: 'sent',
-        colorKey: 'blue',
-      },
-      {
-        id: 3,
-        title: '이지영 사랑해',
-        dateText: '2026.1.3',
-        sentAt: '2026-01-03T09:33:00',
-        direction: 'received',
-        colorKey: 'blue',
-      },
-      {
-        id: 4,
-        title: '안녕하세요 날씨가 좋아...',
-        dateText: '2026.1.3',
-        sentAt: '2026-01-03T09:50:00',
-        direction: 'sent',
-        colorKey: 'pink',
-      },
-      {
-        id: 5,
-        title: '이지영선생님러브러브...',
-        dateText: '2026.1.3',
-        sentAt: '2026-01-03T10:05:00',
-        direction: 'received',
-        colorKey: 'blue',
-      },
-      {
-        id: 6,
-        title: '이지영선생님러브러브...',
-        dateText: '2026.1.3',
-        sentAt: '2026-01-03T10:20:00',
-        direction: 'sent',
-        colorKey: 'cream',
-      },
-    ];
-
-    return [...data].sort((a, b) => new Date(a.sentAt).getTime() - new Date(b.sentAt).getTime());
-  }, []);
 
   // 레인 분리 + 각 레인 내부는 시간순 유지
   const leftLane = useMemo(() => posts.filter((p) => p.direction === 'received'), [posts]);
@@ -150,18 +92,4 @@ function PostCard({ item, onClick }: { item: PostItem; onClick?: () => void }) {
       <p className='mt-1 text-[12px] text-[#6F6F6F]'>{item.dateText}</p>
     </button>
   );
-}
-
-function envelopeBg(key: PostItem['colorKey']) {
-  switch (key) {
-    case 'yellow':
-      return 'bg-[#FFF2B3]';
-    case 'blue':
-      return 'bg-[#D9EEFF]';
-    case 'pink':
-      return 'bg-[#FFD1D1]';
-    case 'cream':
-    default:
-      return 'bg-[#F2F2F2]';
-  }
 }

--- a/src/pages/friend/FriendPostPage.tsx
+++ b/src/pages/friend/FriendPostPage.tsx
@@ -1,27 +1,103 @@
-import { useMemo } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import React, { useMemo } from 'react';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
 
 import BackHeader from '@/components/common/headers/BackHeader';
 import PenIcon from '@/assets/icons/PenIcon.svg?react';
+import { useFriendThread } from '@/hooks/friend/useFriendThread';
+import NotFoundPage from '../system/NotFoundPage';
+import { LoadingDots } from '@/components/LoadingDots';
+import { Button } from '@/components/common/Button';
+import { ENVELOPE_ASSET_MAP } from '@/constants/envelopeAssets';
 
 type Direction = 'received' | 'sent';
 
 type PostItem = {
-  id: number;
+  letterId: number;
   title: string;
-  dateText: string;
-  sentAt: string; // ISO
-  direction: Direction; // received=왼쪽, sent=오른쪽
-  colorKey: 'yellow' | 'blue' | 'pink' | 'cream';
+  deliveredAt: string; // ISO
+  dateText: string; // '2026.01.03'
+  direction: Direction; // received=friendLetters, sent=letters
+  isUnread: boolean;
+
+  paperId: number;
+  stampId: number;
+  stampUrl?: string;
+};
+
+const parseDate = (iso: string) => {
+  const d = new Date(iso);
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}.${m}.${day}`;
 };
 
 export default function FriendPostPage() {
   const navigate = useNavigate();
-  const params = useParams();
+
+  const { friendId: friendIdParam } = useParams();
+  const friendId = Number(friendIdParam);
+  const { data, isLoading, isError, refetch } = useFriendThread(friendId);
+
+  // friendName 불러오기 (friendId는 Param에서 불러옴)
+  const location = useLocation();
+  const friendName = (location.state as { friendName?: string } | null)?.friendName ?? '친구';
+
+  const formattedQuestionTitle = (data?.firstQuestion ?? '').replace(/^질문\s*#\d+:\s*/, '');
+
+  const posts: PostItem[] = useMemo(() => {
+    if (!data) return [];
+
+    const received: PostItem[] = (data.friendLetters ?? []).map((l) => ({
+      letterId: l.id,
+      title: l.title,
+      deliveredAt: l.deliveredAt,
+      dateText: parseDate(l.deliveredAt),
+      direction: 'received',
+      isUnread: l.readAt === null,
+      paperId: l.design.paper.id,
+      stampId: l.design.stamp.id,
+      stampUrl: l.design.stamp.assetUrl,
+    }));
+
+    const sent: PostItem[] = (data.userLetters ?? []).map((l) => ({
+      letterId: l.id,
+      title: l.title,
+      deliveredAt: l.deliveredAt,
+      dateText: parseDate(l.deliveredAt),
+      direction: 'sent',
+      isUnread: false,
+      paperId: l.design.paper.id,
+      stampId: l.design.stamp.id,
+      stampUrl: l.design.stamp.assetUrl,
+    }));
+
+    const merged = [...received, ...sent];
+
+    return merged.sort(
+      (a, b) => new Date(a.deliveredAt).getTime() - new Date(b.deliveredAt).getTime(),
+    );
+  }, [data]);
 
   // 레인 분리 + 각 레인 내부는 시간순 유지
   const leftLane = useMemo(() => posts.filter((p) => p.direction === 'received'), [posts]);
   const rightLane = useMemo(() => posts.filter((p) => p.direction === 'sent'), [posts]);
+
+  // 잘못된 접근 - 404 처리
+  if (!friendIdParam) return <NotFoundPage />;
+
+  const handleOpenLetterDetail = (letterId: number) => {
+    navigate(`/friend/thread/${friendId}/${letterId}`, {
+      state: { friendId, friendName, letterId },
+    });
+  };
+
+  const handleWriteReply = () => {
+    // 우측 하단 플로팅 펜: 새 편지 작성(친구에게 보내는 편지 작성)
+    navigate('/letter/friend/draft', {
+      state: { friendId, friendName },
+    });
+  };
 
   return (
     <div className='min-h-screen bg-[#fafafa]'>
@@ -32,46 +108,70 @@ export default function FriendPostPage() {
           {friendName}님과 이어진 질문
         </div>
 
-        <h2 className='mt-1 ty-title1'>
-          당신의 인생에 가장 큰 영감을
-          <br />
-          주는 사람은 누구인가요?
+        <h2 className='mt-1 ty-title1 leading-[30px] text-[#171717] whitespace-pre-line'>
+          {formattedQuestionTitle}
         </h2>
 
-        {/* 바깥은 2열, 안쪽은 각 레인 flex-col */}
-        <div className='mt-6 grid grid-cols-2 gap-x-[34px] items-start'>
-          {/* 왼쪽 레인 (received) */}
-          <div className='flex flex-col gap-[41px]'>
-            {leftLane.map((p) => (
-              <PostCard
-                key={p.id}
-                item={p}
-                onClick={() => {
-                  // navigate(`/friend/${friendId}/post/${p.id}`);
-                }}
-              />
-            ))}
+        {/* 1) 로딩 */}
+        {isLoading ? (
+          <div className='flex flex-col items-center justify-center gap-8 py-70'>
+            <LoadingDots fillIntervalMs={350} />
+            <p className='ty-title2'>로딩 중...</p>
           </div>
+        ) : /* 2) 에러 */ isError ? (
+          <div className='flex flex-col items-center justify-center gap-8 py-30 text-center'>
+            <p className='ty-title3'>목록을 불러오지 못했어요.</p>
+            <Button type='button' onClick={() => refetch()} className='w-full max-w-[240px]'>
+              다시 시도
+            </Button>
+          </div>
+        ) : (
+          /* 3) 정상 */
+          <>
+            {/* 바깥은 2열, 안쪽은 각 레인 flex-col */}
+            <div className='mt-6 grid grid-cols-2 gap-x-[34px] items-start'>
+              {/* 왼쪽 레인 (received) */}
+              <div className='flex flex-col gap-[41px]'>
+                {leftLane.map((p) => {
+                  const envelopeAsset = ENVELOPE_ASSET_MAP[p.paperId];
+                  const EnvelopePreview = envelopeAsset?.Preview;
 
-          {/* 오른쪽 레인 (sent) - 상단 41px 오프셋 */}
-          <div className='flex flex-col gap-[41px] pt-[41px]'>
-            {rightLane.map((p) => (
-              <PostCard
-                key={p.id}
-                item={p}
-                onClick={() => {
-                  // navigate(`/friend/${friendId}/post/${p.id}`);
-                }}
-              />
-            ))}
-          </div>
-        </div>
+                  return (
+                    <PostCard
+                      key={p.letterId}
+                      item={p}
+                      EnvelopePreview={EnvelopePreview}
+                      onClick={() => handleOpenLetterDetail(p.letterId)}
+                    />
+                  );
+                })}
+              </div>
+
+              {/* 오른쪽 레인 (sent) - 상단 41px 오프셋 */}
+              <div className='flex flex-col gap-[41px] pt-[41px]'>
+                {rightLane.map((p) => {
+                  const envelopeAsset = ENVELOPE_ASSET_MAP[p.paperId];
+                  const EnvelopePreview = envelopeAsset?.Preview;
+
+                  return (
+                    <PostCard
+                      key={p.letterId}
+                      item={p}
+                      EnvelopePreview={EnvelopePreview}
+                      onClick={() => handleOpenLetterDetail(p.letterId)}
+                    />
+                  );
+                })}
+              </div>
+            </div>
+          </>
+        )}
       </main>
 
       {/* 플로팅 작성 버튼 */}
       <button
         type='button'
-        onClick={() => navigate(`/friend/${friendId}/draft`)}
+        onClick={handleWriteReply}
         className='fixed bottom-[112px] right-[calc(50%-187px+20px)] z-50
           h-[56px] w-[56px] rounded-full bg-[var(--color-primary-500)] text-white
           shadow-[0_10px_30px_rgba(0,0,0,0.18)]'
@@ -82,14 +182,46 @@ export default function FriendPostPage() {
   );
 }
 
-function PostCard({ item, onClick }: { item: PostItem; onClick?: () => void }) {
+function PostCard({
+  item,
+  EnvelopePreview,
+  onClick,
+}: {
+  item: PostItem;
+  EnvelopePreview?: React.ComponentType<{ className?: string }>;
+  onClick?: () => void;
+}) {
   return (
     <button type='button' onClick={onClick} className='text-left'>
-      {/* 봉투 자리 */}
-      <div className={`w-[138px] h-[98px] rounded-2xl ${envelopeBg(item.colorKey)}`} />
-      {/* TODO: envelopeBg 다른 페이지에는 paperColor로 되어 있음. 추후 통일 필요 */}
-      <p className='mt-3 line-clamp-1 text-[14px] font-semibold text-[#171717]'>{item.title}</p>
-      <p className='mt-1 text-[12px] text-[#6F6F6F]'>{item.dateText}</p>
+      <div className='relative w-full aspect-[13/10] max-w-[160px]'>
+        {EnvelopePreview ? (
+          <EnvelopePreview className='h-full w-full' />
+        ) : (
+          <div className='h-full w-full rounded-xl bg-[#F2F2F2]' />
+        )}
+
+        {/* 우표(백엔드 assetUrl로) */}
+        {!!item.stampUrl && (
+          <img
+            src={item.stampUrl}
+            alt='우표'
+            className='
+              absolute
+              right-[14px] bottom-[14px]
+              h-[34px] w-[34px]
+              pointer-events-none
+            '
+          />
+        )}
+      </div>
+      <div className='ml-3'>
+        <p className='mt-3 line-clamp-1 ty-body4'>{item.title}</p>
+
+        <div className='mt-1 flex items-center gap-1'>
+          <p className='ty-detailMedium'>{item.dateText}</p>
+          {item.isUnread && <span className='-mt-3 h-[8px] w-[8px] rounded-full bg-[#E06856]' />}
+        </div>
+      </div>
     </button>
   );
 }

--- a/src/pages/friend/FriendPostPage.tsx
+++ b/src/pages/friend/FriendPostPage.tsx
@@ -94,7 +94,7 @@ export default function FriendPostPage() {
 
   const handleWriteReply = () => {
     // 우측 하단 플로팅 펜: 새 편지 작성(친구에게 보내는 편지 작성)
-    navigate('/letter/friend/draft', {
+    navigate('/friend/draft', {
       state: { friendId, friendName },
     });
   };

--- a/src/pages/friend/FriendPostPage.tsx
+++ b/src/pages/friend/FriendPostPage.tsx
@@ -55,9 +55,9 @@ export default function FriendPostPage() {
       dateText: parseDate(l.deliveredAt),
       direction: 'received',
       isUnread: l.readAt === null,
-      paperId: l.design.paper.id,
-      stampId: l.design.stamp.id,
-      stampUrl: l.design.stamp.assetUrl,
+      paperId: (l.design.paper.id ?? 0) + 1,
+      stampId: l.design.stamp.id ?? 0,
+      stampUrl: l.design.stamp.assetUrl ?? '',
     }));
 
     const sent: PostItem[] = (data.userLetters ?? []).map((l) => ({

--- a/src/pages/friend/FriendPostPage.tsx
+++ b/src/pages/friend/FriendPostPage.tsx
@@ -67,9 +67,9 @@ export default function FriendPostPage() {
       dateText: parseDate(l.deliveredAt),
       direction: 'sent',
       isUnread: false,
-      paperId: l.design.paper.id,
-      stampId: l.design.stamp.id,
-      stampUrl: l.design.stamp.assetUrl,
+      paperId: (l.design.paper.id ?? 0) + 1,
+      stampId: l.design.stamp.id ?? 0,
+      stampUrl: l.design.stamp.assetUrl ?? '',
     }));
 
     const merged = [...received, ...sent];
@@ -84,7 +84,7 @@ export default function FriendPostPage() {
   const rightLane = useMemo(() => posts.filter((p) => p.direction === 'sent'), [posts]);
 
   // 잘못된 접근 - 404 처리
-  if (!friendIdParam) return <NotFoundPage />;
+  if (!friendIdParam || !Number.isFinite(friendId) || friendId <= 0) return <NotFoundPage />;
 
   const handleOpenLetterDetail = (letterId: number) => {
     navigate(`/friend/thread/${friendId}/${letterId}`, {

--- a/src/pages/friend/FriendReplyPage.tsx
+++ b/src/pages/friend/FriendReplyPage.tsx
@@ -110,7 +110,7 @@ export default function FriendReplyPage() {
   };
 
   const content = isLoading ? (
-    <div className='flex flex-col items-center justify-center gap-8 py-50'>
+    <div className='flex flex-col items-center justify-center gap-8 py-70'>
       <LoadingDots fillIntervalMs={350} />
       <p className='ty-title2'>로딩 중...</p>
     </div>

--- a/src/pages/friend/FriendReplyPage.tsx
+++ b/src/pages/friend/FriendReplyPage.tsx
@@ -1,0 +1,154 @@
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
+import { useLetterDetail } from '@/hooks/letters/useLetterDetail';
+import { useMemo } from 'react';
+
+import BackHeader from '@/components/common/headers/BackHeader';
+import { Button } from '@/components/common/Button';
+import { LoadingDots } from '@/components/LoadingDots';
+import NotFoundPage from '../system/NotFoundPage';
+import LetterCard from '@/components/letters/LetterCard';
+import { DEFAULT_FONT_ID, FONT_ASSET_MAP } from '@/constants/fontAssets';
+import { DEFAULT_PAPER_ID, PAPER_ASSET_MAP } from '@/constants/paperAssets';
+
+type ReplyData = {
+  title: string;
+  sentAtText: string;
+  question: string;
+  content: string;
+  paperId: number;
+  fontId: number;
+  stampId: number;
+  stampUrl: string;
+};
+
+const parseSentAt = (isoOrNull: string | null) => {
+  if (!isoOrNull) return '-';
+
+  const d = new Date(isoOrNull);
+  if (Number.isNaN(d.getTime())) return '-';
+
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+
+  let hours = d.getHours(); // 0 ~ 23
+  const minutes = String(d.getMinutes()).padStart(2, '0');
+
+  const isPM = hours >= 12;
+  const ampm = isPM ? 'PM' : 'AM';
+
+  hours = hours % 12;
+  if (hours === 0) hours = 12;
+
+  const hh = String(hours).padStart(2, '0');
+
+  return `${y}.${m}.${day} ${hh}:${minutes} ${ampm}`;
+};
+
+export default function FriendReplyPage() {
+  const navigate = useNavigate();
+
+  // letterId, friendId Param으로 불러오기
+  const { letterId: letterIdParam } = useParams();
+  const { friendId: friendIdParam } = useParams();
+  const letterId = letterIdParam ? Number(letterIdParam) : 0;
+  const friendId = Number(friendIdParam);
+
+  const { data, isLoading, isError, refetch } = useLetterDetail(letterId);
+
+  // FriendName 불러오기
+  const location = useLocation();
+  const friendName = (location.state as { friendName?: string } | null)?.friendName ?? '친구';
+
+  const view = useMemo<ReplyData | null>(() => {
+    if (!data) return null;
+
+    return {
+      title: data.title,
+      sentAtText: parseSentAt(data.deliveredAt),
+      question: data.question,
+      content: data.content,
+      paperId: (data.design.paper.id ?? 0) + 1,
+      fontId: data.design.font.id ?? 0,
+      stampId: data.design.stamp.id ?? 0,
+      stampUrl: data.design.stamp.assetUrl ?? '',
+    };
+  }, [data]);
+
+  const formattedQuestionTitle = (data?.question ?? '').replace(/^질문\s*#\d+:\s*/, '');
+
+  const assets = useMemo(() => {
+    if (!view) return null;
+
+    const font = FONT_ASSET_MAP[view.fontId] ?? FONT_ASSET_MAP[DEFAULT_FONT_ID];
+    const paper = PAPER_ASSET_MAP[view.paperId] ?? PAPER_ASSET_MAP[DEFAULT_PAPER_ID];
+
+    return { font, paper };
+  }, [view]);
+
+  // 잘못된 접근 - 404 처리
+  if (!letterIdParam) return <NotFoundPage />;
+
+  const handleReport = () => {
+    navigate('/letter/report');
+  };
+
+  const handleReply = () => {
+    navigate('/friend/draft', {
+      state: { friendId, friendName },
+    });
+  };
+
+  const content = isLoading ? (
+    <div className='flex flex-col items-center justify-center gap-8 py-50'>
+      <LoadingDots fillIntervalMs={350} />
+      <p className='ty-title2'>로딩 중...</p>
+    </div>
+  ) : isError || !view || !assets ? (
+    <div className='flex flex-col items-center justify-center gap-8 py-30 text-center'>
+      <p className='ty-title3'>편지를 불러오지 못했어요.</p>
+      <Button type='button' onClick={() => refetch()} className='w-full max-w-[240px]'>
+        다시 시도
+      </Button>
+    </div>
+  ) : (
+    <>
+      {/* 날짜/시간 + 질문 */}
+      <p className='ty-body5 text-[var(--color-text-normal)]'>{view.sentAtText}</p>
+
+      <h1 className='mt-1 whitespace-pre-line ty-title2 leading-[140%] text-[var(--color-text-normal)]'>
+        {formattedQuestionTitle}
+      </h1>
+
+      {/* 편지지 컴포넌트 */}
+      <LetterCard
+        PaperBg={assets.paper.Preview}
+        font={assets.font.fontFamily}
+        value={{ title: view.title, content: view.content }}
+        className='rotate-1 mt-5'
+      />
+
+      <Button className='w-full mt-6' onClick={handleReply}>
+        답장하기
+      </Button>
+    </>
+  );
+
+  return (
+    <div className='min-h-dvh bg-[var(--color-bg-500)]'>
+      <BackHeader
+        title={`${friendName}님의 편지`}
+        rightElement={
+          <button
+            type='button'
+            onClick={handleReport}
+            className='ty-body5 font-medium text-[var(--color-primary-500)]'
+          >
+            신고하기
+          </button>
+        }
+      />
+      <main className='px-5 pb-[28px]'>{content}</main>
+    </div>
+  );
+}

--- a/src/pages/friend/FriendReplyPage.tsx
+++ b/src/pages/friend/FriendReplyPage.tsx
@@ -9,6 +9,7 @@ import NotFoundPage from '../system/NotFoundPage';
 import LetterCard from '@/components/letters/LetterCard';
 import { DEFAULT_FONT_ID, FONT_ASSET_MAP } from '@/constants/fontAssets';
 import { DEFAULT_PAPER_ID, PAPER_ASSET_MAP } from '@/constants/paperAssets';
+import { useLetterStore } from '@/stores/letterStore';
 
 type ReplyData = {
   title: string;
@@ -55,6 +56,7 @@ export default function FriendReplyPage() {
   const friendId = Number(friendIdParam);
 
   const { data, isLoading, isError, refetch } = useLetterDetail(letterId);
+  const { setActiveTarget, patchDraft } = useLetterStore();
 
   // FriendName 불러오기
   const location = useLocation();
@@ -94,8 +96,16 @@ export default function FriendReplyPage() {
   };
 
   const handleReply = () => {
-    navigate('/friend/draft', {
-      state: { friendId, friendName },
+    setActiveTarget('friend');
+
+    patchDraft({
+      receiverUserId: friendId,
+    });
+
+    navigate('/letter/friend/draft', {
+      state: {
+        friendName,
+      },
     });
   };
 

--- a/src/pages/friend/FriendReplyPage.tsx
+++ b/src/pages/friend/FriendReplyPage.tsx
@@ -50,10 +50,9 @@ export default function FriendReplyPage() {
   const navigate = useNavigate();
 
   // letterId, friendId Param으로 불러오기
-  const { letterId: letterIdParam } = useParams();
-  const { friendId: friendIdParam } = useParams();
+  const { letterId: letterIdParam, friendId: friendIdParam } = useParams();
   const letterId = letterIdParam ? Number(letterIdParam) : 0;
-  const friendId = Number(friendIdParam);
+  const friendId = friendIdParam ? Number(friendIdParam) : 0;
 
   const { data, isLoading, isError, refetch } = useLetterDetail(letterId);
   const { setActiveTarget, patchDraft } = useLetterStore();
@@ -89,7 +88,7 @@ export default function FriendReplyPage() {
   }, [view]);
 
   // 잘못된 접근 - 404 처리
-  if (!letterIdParam) return <NotFoundPage />;
+  if (!letterIdParam || !friendIdParam || Number.isNaN(friendId)) return <NotFoundPage />;
 
   const handleReport = () => {
     navigate('/letter/report');

--- a/src/pages/friend/FriendReplyPage.tsx
+++ b/src/pages/friend/FriendReplyPage.tsx
@@ -102,7 +102,7 @@ export default function FriendReplyPage() {
       receiverUserId: friendId,
     });
 
-    navigate('/letter/friend/draft', {
+    navigate('/friend/draft', {
       state: {
         friendName,
       },

--- a/src/pages/friend/FriendRequestPage.tsx
+++ b/src/pages/friend/FriendRequestPage.tsx
@@ -57,7 +57,7 @@ export default function FriendRequestPage() {
 
     patchDraft({ receiverUserId: user.id });
 
-    navigate('/letter/deco/friend');
+    navigate('/friend/draft');
   };
 
   const handleAccept = (user: RequestUser) => {

--- a/src/pages/friend/FriendRequestPage.tsx
+++ b/src/pages/friend/FriendRequestPage.tsx
@@ -10,6 +10,7 @@ import { useOutgoingFriendRequests } from '@/hooks/friend/useOutgoingFriendReque
 import { useAcceptFriendRequest } from '@/hooks/friend/useAcceptFriendRequest';
 import { useRejectFriendRequest } from '@/hooks/friend/useRejectFriendRequest';
 import { useCancelFriendRequest } from '@/hooks/friend/useCancelFriendRequest';
+import { useLetterStore } from '@/stores/letterStore';
 
 type RequestUser = {
   id: number;
@@ -20,7 +21,13 @@ export default function FriendRequestPage() {
   const navigate = useNavigate();
   const openModal = useModalStore((s) => s.openModal);
 
+  const setActiveTarget = useLetterStore((s) => s.setActiveTarget);
+  const patchDraft = useLetterStore((s) => s.patchDraft);
   const { data: incoming = [] } = useIncomingFriendRequests();
+  // TODO : 이전 friend draft를 리셋해야 하는가?
+  // 이전 friend draft 임시저장 -> 다른 친구에게 새로 작성하려고 하면 모달 띄우기
+  // (임시 저장된 글이 있습니다. 삭제하고 새로 작성하시겠어요?)
+  // const resetCurrent = useLetterStore((s) => s.resetCurrent);
   const { data: outgoing = [] } = useOutgoingFriendRequests();
 
   const acceptMutation = useAcceptFriendRequest();
@@ -45,6 +52,14 @@ export default function FriendRequestPage() {
     [outgoing],
   );
 
+  const goWriteLetterTo = (user: RequestUser) => {
+    setActiveTarget('friend');
+
+    patchDraft({ receiverUserId: user.id });
+
+    navigate('/letter/deco/friend');
+  };
+
   const handleAccept = (user: RequestUser) => {
     acceptMutation.mutate(user.id, {
       onSuccess: () => {
@@ -52,7 +67,7 @@ export default function FriendRequestPage() {
           friendName: user.name,
           onConfirm: () => {},
           onWriteLetter: () => {
-            // TODO: letterId 연결
+            goWriteLetterTo(user);
           },
         });
       },

--- a/src/pages/friend/FriendSentTransitionPage.tsx
+++ b/src/pages/friend/FriendSentTransitionPage.tsx
@@ -5,23 +5,27 @@ import { useModalStore } from '@/stores/modalStore';
 import ToastPopup from '@/components/ToastPopup';
 import useToast from '@/hooks/useToast';
 import { useState } from 'react';
+import { useThreadFlowStore } from '@/stores/letterContext';
+import NotFoundPage from '../system/NotFoundPage';
 
 export default function FriendSentTransitionPage() {
   const { openModal } = useModalStore();
   const { toast, visible, showToast, closeToast } = useToast();
 
+  const senderName = useThreadFlowStore((s) => s.senderName ?? '익명');
+  const threadId = useThreadFlowStore((s) => s.threadId);
+
   const navigate = useNavigate();
 
   const [isRequested, setIsRequested] = useState(false);
 
-  // mock data
-  // TODO : 앞 페이지랑 props 연결하기
-  const receiver = '파란수박';
-  const letterId = '1';
+  if (!threadId) {
+    return <NotFoundPage />;
+  }
 
   const handleFriendRequest = () => {
     openModal('friendRequest', {
-      receiverName: receiver,
+      receiverName: senderName,
       onConfirmFriendRequest: () => {
         setIsRequested(true);
         showToast('친구 신청이 완료되었습니다!', 'success');
@@ -30,7 +34,7 @@ export default function FriendSentTransitionPage() {
   };
 
   const handleGoToReview = () => {
-    navigate(`/letter/review/${letterId}`);
+    navigate(`/letter/review/${threadId}`);
   };
 
   return (
@@ -38,7 +42,7 @@ export default function FriendSentTransitionPage() {
       {/* Header */}
       <header className='flex flex-col justify-start gap-2'>
         <p className='ty-body1 leading-tight'>
-          {receiver}님과 <span className='text-(--color-primary-500)'>10회</span>의 대화를
+          {senderName}님과 <span className='text-(--color-primary-500)'>10회</span>의 대화를
           <br />
           모두 나누었어요.
         </p>
@@ -49,7 +53,7 @@ export default function FriendSentTransitionPage() {
       <section className='mt-15 flex flex-col items-center'>
         <LetterEndedEnvelope className='block' />
         <Link
-          to={`/friend/post/${letterId}`}
+          to={`/letter/thread/${threadId}`}
           className='ty-body5 text-(--color-text-assistive) mt-3 underline underline-offset-4'
         >
           우리가 나눴던 대화 다시보기

--- a/src/pages/letter/AnonDraftPage.tsx
+++ b/src/pages/letter/AnonDraftPage.tsx
@@ -10,11 +10,7 @@ import { useModalStore } from '@/stores/modalStore';
 import { useEffect, useMemo, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import LoadingPage from '../system/LoadingPage';
-
-const LIMIT = {
-  TITLE: { MIN: 3, MAX: 20 },
-  CONTENT: { MIN: 1, MAX: 500 },
-} as const;
+import { validateLetter } from '@/utils/validateLetter';
 
 const AnonDraftPage = () => {
   const { data, isLoading, isError, error } = useDailyQuestion();
@@ -50,21 +46,10 @@ const AnonDraftPage = () => {
     navigate(-1);
   };
 
-  const validate = (title: string, content: string) => {
-    if (title.length < LIMIT.TITLE.MIN) return `제목을 ${LIMIT.TITLE.MIN}자 이상 입력해주세요.`;
-    if (title.length > LIMIT.TITLE.MAX)
-      return `제목은 최대 ${LIMIT.TITLE.MAX}자까지 입력할 수 있어요.`;
-    if (content.length < LIMIT.CONTENT.MIN) return '내용을 작성해 주세요!';
-    if (content.length > LIMIT.CONTENT.MAX)
-      return `내용은 최대 ${LIMIT.CONTENT.MAX}자까지 입력할 수 있어요.`;
-
-    return null;
-  };
-
   const handleSubmit = () => {
     const title = draft.title.trim();
     const content = draft.content.trim();
-    const errorMsg = validate(title, content);
+    const errorMsg = validateLetter(title, content);
 
     if (errorMsg) {
       showToast(errorMsg, 'error');

--- a/src/pages/letter/LetterDecoPage.tsx
+++ b/src/pages/letter/LetterDecoPage.tsx
@@ -32,6 +32,7 @@ function LetterDecoPage() {
   // senderName 불러오기
   const location = useLocation();
   const senderName = (location.state as { senderName?: string } | null)?.senderName ?? '익명';
+  const friendName = (location.state as { friendName?: string } | null)?.friendName ?? '친구';
 
   const { target } = useParams<{ target?: string }>();
 
@@ -102,9 +103,10 @@ function LetterDecoPage() {
     }
 
     openModal('letterSendingConfirm', {
+      friendName,
       onConfirmSending: () => {
         navigate(`/letter/${safeMode}/sending`, {
-          state: { senderName },
+          state: { senderName, friendName },
         });
       },
       onConfirmCancelSending: () => setIsOpen(true),

--- a/src/pages/letter/LetterInboxOtherPage.tsx
+++ b/src/pages/letter/LetterInboxOtherPage.tsx
@@ -22,25 +22,21 @@ type InboxOtherLetterItem = {
   receivedAtMs: number; // Sorting용
   isUnread: boolean;
   paperId: number;
-  // stampId: number; // TODO : 백엔드 필드 수정 후 연동 필요
-  // stampUrl: string;
+  stampId: number; // TODO : 백엔드 필드 수정 후 연동 필요
+  stampUrl: string;
 };
 
-const parseDate = (iso: string) => {
-  const d = new Date(iso);
-  const fmt = new Intl.DateTimeFormat('ko-KR', {
-    timeZone: 'Asia/Seoul',
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-  });
-  const parts = Object.fromEntries(
-    fmt
-      .formatToParts(d)
-      .filter((p) => p.type !== 'literal')
-      .map((p) => [p.type, p.value]),
-  );
-  return `${parts.year}.${parts.month}.${parts.day}`;
+const parseDate = (input: string | null | undefined) => {
+  if (!input) return '-';
+
+  const d = new Date(input);
+  if (Number.isNaN(d.getTime())) return '-';
+
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+
+  return `${y}.${m}.${day}`;
 };
 
 export default function LetterInboxOtherPage() {
@@ -51,51 +47,26 @@ export default function LetterInboxOtherPage() {
   const [keyword, setKeyword] = useState('');
   const [sortOrder, setSortOrder] = useState<SortOrder>('latest');
 
-  const DUMMY_MAILBOX_LETTERS = [
-    {
-      threadId: 1,
-      sender: { id: 2, nickname: '파란수박' },
-      lastLetterId: 9001,
-      lastLetterTitle: '요즘 제일 행복한 순간은?',
-      lastLetterPreview: '나는 요즘…',
-      updatedAt: new Date().toISOString(),
-      paperId: 0,
-    },
-    {
-      threadId: 2,
-      sender: { id: 3, nickname: '초록오이' },
-      lastLetterId: 9002,
-      lastLetterTitle: '오늘 하루를 한 단어로 말하면?',
-      lastLetterPreview: '음…',
-      updatedAt: new Date(Date.now() - 1000 * 60 * 60 * 24).toISOString(),
-      paperId: 1,
-    },
-    {
-      threadId: 3,
-      sender: { id: 4, nickname: '노란치즈' },
-      lastLetterId: 9003,
-      lastLetterTitle: '너가 제일 자주 하는 생각은?',
-      lastLetterPreview: '나는…',
-      updatedAt: new Date(Date.now() - 1000 * 60 * 60 * 24 * 3).toISOString(),
-      paperId: 2,
-    },
-  ] as const;
-
-  // 서버 응답을 화면 아이템으로 변환 (isUnread 제외)
+  // 서버 응답을 화면 아이템으로 변환
   const items: InboxOtherLetterItem[] = useMemo(() => {
     const serverLetters = data?.letters ?? [];
-    const raw = serverLetters.length > 0 ? serverLetters : DUMMY_MAILBOX_LETTERS;
 
-    return raw.map((x) => ({
-      letterId: x.lastLetterId,
-      threadId: x.threadId,
-      question: x.lastLetterTitle,
-      senderName: x.sender.nickname, // 서버에서 내려주는 랜덤 닉네임
-      receivedAt: parseDate(x.updatedAt),
-      receivedAtMs: new Date(x.updatedAt).getTime(),
-      isUnread: false,
-      paperId: x.paperId + 1,
-    }));
+    return serverLetters.map((x) => {
+      const deliveredAt = x.deliveredAt; // ISO string
+
+      return {
+        letterId: x.lastLetterId,
+        threadId: x.threadId,
+        question: x.lastLetterTitle,
+        senderName: x.sender.nickname,
+        receivedAt: parseDate(deliveredAt),
+        receivedAtMs: new Date(deliveredAt).getTime(),
+        isUnread: false,
+        paperId: x.design?.paper?.id ?? 0,
+        stampId: x.stampId ?? 0,
+        stampUrl: (x.stampUrl ?? '').trim(),
+      };
+    });
   }, [data]);
 
   const filtered = useMemo(() => {
@@ -205,6 +176,16 @@ export default function LetterInboxOtherPage() {
                               <div className='h-full w-full rounded-xl bg-[#F2F2F2]' />
                             )}
                           </div>
+
+                          {!!it.stampUrl && (
+                            <img
+                              src={it.stampUrl}
+                              alt=''
+                              className='absolute right-1 bottom-3 h-7 w-7 object-contain pointer-events-none'
+                              draggable={false}
+                            />
+                          )}
+
                           {/* 오른쪽 하단 날짜 */}
                           <div className='flex justify-end pr-2 ty-detailMedium text-[var(--color-text-normal)]'>
                             {it.receivedAt}

--- a/src/pages/letter/LetterInboxOtherPage.tsx
+++ b/src/pages/letter/LetterInboxOtherPage.tsx
@@ -120,7 +120,7 @@ export default function LetterInboxOtherPage() {
     }
   };
 
-  const handleOpenLetter = (item: InboxOtherLetterItem) => {
+  const handleOpenThread = (item: InboxOtherLetterItem) => {
     navigate(`/letter/thread/${item.threadId}`, {
       state: { senderName: item.senderName },
     });
@@ -179,7 +179,7 @@ export default function LetterInboxOtherPage() {
                     <button
                       key={it.letterId}
                       type='button'
-                      onClick={() => handleOpenLetter(it)}
+                      onClick={() => handleOpenThread(it)}
                       className='w-full h-[129px] rounded-xl bg-white p-4 text-left shadow-[0_8px_24px_rgba(0,0,0,0.06)]'
                     >
                       <div className='flex items-start justify-between gap-3'>

--- a/src/pages/letter/LetterInboxOtherPage.tsx
+++ b/src/pages/letter/LetterInboxOtherPage.tsx
@@ -10,19 +10,20 @@ import { useAnonMailbox } from '@/hooks/mails/useAnonMailbox';
 import { LoadingDots } from '@/components/LoadingDots';
 import { Button } from '@/components/common/Button';
 import { ENVELOPE_ASSET_MAP } from '@/constants/envelopeAssets';
+import { useThreadFlowStore } from '@/stores/letterContext';
 
 type SortOrder = 'latest' | 'oldest';
 
 type InboxOtherLetterItem = {
   letterId: number;
-  threadId: number;
+  threadId: number; // inbox-other에서 처음 저장되는데, receiverUserId, senderUser과 같다.
   question: string;
-  senderName: string;
+  senderName: string; // 랜덤 익명 닉네임 (TODO : 유틸 함수 사용해서 발급 필요)
   receivedAt: string; // 화면 표시용 (YYYY.MM.DD)
   receivedAtMs: number; // Sorting용
   isUnread: boolean;
   paperId: number;
-  stampId: number; // TODO : 백엔드 필드 수정 후 연동 필요
+  stampId: number;
   stampUrl: string;
 };
 
@@ -42,6 +43,7 @@ const parseDate = (input: string | null | undefined) => {
 export default function LetterInboxOtherPage() {
   const navigate = useNavigate();
   const { data, isError, isLoading, refetch } = useAnonMailbox();
+  const setFlow = useThreadFlowStore((s) => s.setFlow);
 
   const [tab, setTab] = useState<LetterInboxTabKey>('other');
   const [keyword, setKeyword] = useState('');
@@ -56,7 +58,7 @@ export default function LetterInboxOtherPage() {
 
       return {
         letterId: x.lastLetterId,
-        threadId: x.threadId,
+        threadId: x.threadId, // = receiverUserId, senderName's id
         question: x.lastLetterTitle,
         senderName: x.sender.nickname,
         receivedAt: parseDate(deliveredAt),
@@ -92,9 +94,15 @@ export default function LetterInboxOtherPage() {
   };
 
   const handleOpenThread = (item: InboxOtherLetterItem) => {
-    navigate(`/letter/thread/${item.threadId}`, {
-      state: { senderName: item.senderName },
+    // Store에 아래 항목 저장
+    setFlow({
+      target: 'other',
+      threadId: item.threadId,
+      senderName: item.senderName,
+      friendName: null,
     });
+
+    navigate(`/letter/thread/${item.threadId}`);
   };
 
   const isEmpty = !isLoading && !isError && filtered.length === 0;

--- a/src/pages/letter/LetterInboxSelfPage.tsx
+++ b/src/pages/letter/LetterInboxSelfPage.tsx
@@ -166,7 +166,7 @@ export default function LetterInboxSelfPage() {
                           )}
                         </div>
 
-                        <div className='flex flex-col'>
+                        <div className='relative flex flex-col'>
                           {/* 오른쪽 봉투 썸네일 */}
                           <div className='h-23 w-25 shrink-0 flex items-center justify-center -mt-3'>
                             {EnvelopePreview ? (

--- a/src/pages/letter/LetterInboxSelfPage.tsx
+++ b/src/pages/letter/LetterInboxSelfPage.tsx
@@ -15,31 +15,27 @@ type SortOrder = 'latest' | 'oldest';
 
 type InboxSelfLetterItem = {
   letterId: number;
-  // questionId: number; // TODO : 백엔드 필드 수정 후 연동 필요
+  questionId: number; // TODO : 백엔드 필드 수정 후 연동 필요
   title: string;
   receivedAt: string; // 화면 표시용 (YYYY.MM.DD)
   receivedAtMs: number; // Sorting용
   isUnread: boolean;
   paperId: number;
-  // stampId: number; // TODO : 백엔드 필드 수정 후 연동 필요
-  // stampUrl: string;
+  stampId: number; // TODO : 백엔드 필드 수정 후 연동 필요
+  stampUrl: string;
 };
 
-const parseDate = (iso: string) => {
-  const d = new Date(iso);
-  const fmt = new Intl.DateTimeFormat('ko-KR', {
-    timeZone: 'Asia/Seoul',
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-  });
-  const parts = Object.fromEntries(
-    fmt
-      .formatToParts(d)
-      .filter((p) => p.type !== 'literal')
-      .map((p) => [p.type, p.value]),
-  );
-  return `${parts.year}.${parts.month}.${parts.day}`;
+const parseDate = (input: string | null | undefined) => {
+  if (!input) return '-';
+
+  const d = new Date(input);
+  if (Number.isNaN(d.getTime())) return '-';
+
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+
+  return `${y}.${m}.${day}`;
 };
 
 export default function LetterInboxSelfPage() {
@@ -52,15 +48,18 @@ export default function LetterInboxSelfPage() {
 
   // 서버 응답 -> 화면 아이템으로 변환 (isUnread 제외)
   const items: InboxSelfLetterItem[] = useMemo(() => {
-    const raw = data?.items ?? [];
+    const raw = data?.letters ?? [];
 
     return raw.map((x) => ({
       letterId: x.id,
+      questionId: x.questionId,
       title: x.title,
       receivedAt: parseDate(x.createdAt),
       receivedAtMs: new Date(x.createdAt).getTime(),
       isUnread: false,
       paperId: x.paperId + 1,
+      stampId: x.stampId,
+      stampUrl: x.stampUrl,
     }));
   }, [data]);
 
@@ -176,6 +175,16 @@ export default function LetterInboxSelfPage() {
                               <div className='h-full w-full rounded-xl bg-[#F2F2F2]' />
                             )}
                           </div>
+
+                          {!!it.stampUrl && (
+                            <img
+                              src={it.stampUrl}
+                              alt=''
+                              className='absolute right-1 bottom-3 h-7 w-7 object-contain pointer-events-none'
+                              draggable={false}
+                            />
+                          )}
+
                           {/* 오른쪽 하단 날짜 */}
                           <div className='flex justify-end pr-2 ty-detailMedium text-[var(--color-text-normal)]'>
                             {it.receivedAt}

--- a/src/pages/letter/LetterPostOtherPage.tsx
+++ b/src/pages/letter/LetterPostOtherPage.tsx
@@ -185,7 +185,6 @@ export default function LetterPostOtherPage() {
         className='fixed bottom-[112px] right-[calc(50%-187px+20px)] z-50
           h-[56px] w-[56px] rounded-full bg-[var(--color-primary-500)] text-white
           shadow-[0_10px_30px_rgba(0,0,0,0.18)]'
-        aria-label='답장 작성'
       >
         <PenIcon className='ml-3.5' />
       </button>

--- a/src/pages/letter/LetterPostOtherPage.tsx
+++ b/src/pages/letter/LetterPostOtherPage.tsx
@@ -71,7 +71,7 @@ export default function LetterPostOtherPage() {
   const rightLane = useMemo(() => posts.filter((p) => p.isMine === true), [posts]);
 
   // 잘못된 접근 - 404 처리
-  if (!threadIdParam) return <NotFoundPage />;
+  if (!threadIdParam || !threadId) return <NotFoundPage />;
 
   const handleOpenLetterDetail = (letterId: number) => {
     navigate(`/letter/reply/${threadId}/${letterId}`, {

--- a/src/pages/letter/LetterPostOtherPage.tsx
+++ b/src/pages/letter/LetterPostOtherPage.tsx
@@ -18,7 +18,7 @@ type PostItem = {
   isUnread: boolean;
   paperId: number;
   stampId: number;
-  stampUrl?: string; // TODO : 백엔드에서 받으면 ? 제거
+  stampUrl: string;
 };
 
 const parseDate = (iso: string) => {
@@ -40,55 +40,21 @@ export default function LetterPostOtherPage() {
   const location = useLocation();
   const senderName = (location.state as { senderName?: string } | null)?.senderName ?? '익명';
 
-  const questionTitle = data?.firstQuestion ?? '첫번째로 받은 질문입니다.';
+  const formattedQuestionTitle = (data?.firstQuestion ?? '').replace(/^질문\s*#\d+:\s*/, '');
 
-  const DUMMY_POSTS: PostItem[] = [
-    {
-      letterId: 1,
-      title: '첫 번째 편지예요',
-      deliveredAt: '2026-01-01T10:00:00.000Z',
-      dateText: '2026.01.01',
-      isMine: false,
-      isUnread: true,
-      paperId: 1,
-      stampId: 1,
-    },
-    {
-      letterId: 2,
-      title: '답장을 보냈어요',
-      deliveredAt: '2026-01-02T12:30:00.000Z',
-      dateText: '2026.01.02',
-      isMine: true,
+  const posts = useMemo<PostItem[]>(() => {
+    const letters = data?.letters ?? [];
+    return letters.map((l) => ({
+      letterId: l.id,
+      title: l.title,
+      deliveredAt: l.deliveredAt,
+      dateText: parseDate(l.deliveredAt),
+      isMine: l.isMine,
       isUnread: false,
-      paperId: 2,
-      stampId: 2,
-    },
-    {
-      letterId: 3,
-      title: '또 다른 편지',
-      deliveredAt: '2026-01-03T18:20:00.000Z',
-      dateText: '2026.01.03',
-      isMine: false,
-      isUnread: false,
-      paperId: 1,
-      stampId: 3,
-    },
-  ];
-
-  const posts: PostItem[] = useMemo(() => {
-    if (data?.letters && data.letters.length > 0) {
-      return data.letters.map((l) => ({
-        letterId: l.id,
-        title: l.title,
-        deliveredAt: l.deliveredAt,
-        dateText: parseDate(l.deliveredAt),
-        isMine: false,
-        isUnread: false,
-        paperId: l.design.paper.id + 1,
-        stampId: l.design.stamp.id,
-      }));
-    }
-    return DUMMY_POSTS;
+      paperId: l.paperId + 1,
+      stampId: l.stampId,
+      stampUrl: l.stampUrl,
+    }));
   }, [data?.letters]);
 
   // 레인 분리 + 각 레인 내부는 시간순 유지
@@ -119,7 +85,7 @@ export default function LetterPostOtherPage() {
         <div className='mt-2 text-[13px] text-[#6F6F6F]'>{senderName}님과 이어진 질문</div>
 
         <h2 className='mt-1 ty-title1 leading-[30px] text-[#171717] whitespace-pre-line'>
-          {questionTitle}
+          {formattedQuestionTitle}
         </h2>
 
         {/* 1) 로딩 */}

--- a/src/pages/letter/LetterPostOtherPage.tsx
+++ b/src/pages/letter/LetterPostOtherPage.tsx
@@ -1,5 +1,5 @@
-import React, { useMemo } from 'react';
-import { useLocation, useNavigate, useParams } from 'react-router-dom';
+import React, { useEffect, useMemo } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
 
 import BackHeader from '@/components/common/headers/BackHeader';
 import PenIcon from '@/assets/icons/PenIcon.svg?react';
@@ -8,6 +8,7 @@ import { useAnonThread } from '@/hooks/mails/useAnonThread';
 import { Button } from '@/components/common/Button';
 import { LoadingDots } from '@/components/LoadingDots';
 import { ENVELOPE_ASSET_MAP } from '@/constants/envelopeAssets';
+import { useThreadFlowStore } from '@/stores/letterContext';
 
 type PostItem = {
   letterId: number;
@@ -32,13 +33,12 @@ const parseDate = (iso: string) => {
 export default function LetterPostOtherPage() {
   const navigate = useNavigate();
   const { threadId: threadIdParam } = useParams();
-
   const threadId = threadIdParam ? Number(threadIdParam) : 0;
-  const { data, isLoading, isError, refetch } = useAnonThread(threadId);
 
-  // SenderName 불러오기
-  const location = useLocation();
-  const senderName = (location.state as { senderName?: string } | null)?.senderName ?? '익명';
+  const setFlow = useThreadFlowStore((s) => s.setFlow);
+  const senderName = useThreadFlowStore((s) => s.senderName) ?? '익명';
+
+  const { data, isLoading, isError, refetch } = useAnonThread(threadId);
 
   const formattedQuestionTitle = (data?.firstQuestion ?? '').replace(/^질문\s*#\d+:\s*/, '');
 
@@ -57,6 +57,15 @@ export default function LetterPostOtherPage() {
     }));
   }, [data?.letters]);
 
+  // store에 컨텍스트 동기화 (새로고침 대비, 다음 페이지에서 사용하기 위해)
+  useEffect(() => {
+    setFlow({
+      target: 'other',
+      threadId,
+      senderName: senderName,
+    });
+  }, [setFlow, threadId, senderName]);
+
   // 레인 분리 + 각 레인 내부는 시간순 유지
   const leftLane = useMemo(() => posts.filter((p) => p.isMine === false), [posts]);
   const rightLane = useMemo(() => posts.filter((p) => p.isMine === true), [posts]);
@@ -72,9 +81,8 @@ export default function LetterPostOtherPage() {
 
   const handleWriteReply = () => {
     // 우측 하단 플로팅 펜: 답장 작성(익명 상대에게 보내는 편지 작성)
-    navigate('/letter/other/draft', {
-      state: { threadId, senderName },
-    });
+    navigate('/letter/other/draft');
+    // senderName, threadId는 letterContext store에 저장되어 있다.
   };
 
   return (

--- a/src/pages/letter/LetterPostSelfPage.tsx
+++ b/src/pages/letter/LetterPostSelfPage.tsx
@@ -66,6 +66,13 @@ export default function LetterPostSelfPage() {
     };
   }, [data]);
 
+  const stripQuestionPrefix = (s: string) => s.replace(/^질문\s*#\d+:\s*/, '');
+
+  const formattedQuestionTitle = useMemo(() => {
+    const q = view?.question ?? data?.question ?? '';
+    return stripQuestionPrefix(q);
+  }, [view?.question, data?.question]);
+
   const assets = useMemo(() => {
     if (!view) return null;
 
@@ -100,7 +107,7 @@ export default function LetterPostSelfPage() {
       <p className='ty-body5 text-[var(--color-text-normal)]'>{view.sentAtText}</p>
 
       <h1 className='mt-1 whitespace-pre-line ty-title2 leading-[140%] text-[var(--color-text-normal)]'>
-        {view.question}
+        {formattedQuestionTitle}
       </h1>
 
       {/* 편지지 컴포넌트 */}

--- a/src/pages/letter/LetterReplyPage.tsx
+++ b/src/pages/letter/LetterReplyPage.tsx
@@ -1,4 +1,4 @@
-import { useLocation, useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import { useLetterDetail } from '@/hooks/letters/useLetterDetail';
 import { useMemo } from 'react';
 
@@ -10,6 +10,7 @@ import LetterCard from '@/components/letters/LetterCard';
 import { DEFAULT_FONT_ID, FONT_ASSET_MAP } from '@/constants/fontAssets';
 import { DEFAULT_PAPER_ID, PAPER_ASSET_MAP } from '@/constants/paperAssets';
 import { useModalStore } from '@/stores/modalStore';
+import { useThreadFlowStore } from '@/stores/letterContext';
 
 type ReplyData = {
   title: string;
@@ -50,11 +51,11 @@ export default function LetterReplyPage() {
   const navigate = useNavigate();
   const { letterId: letterIdParam } = useParams();
   const letterId = letterIdParam ? Number(letterIdParam) : 0;
+
+  const senderName = useThreadFlowStore((s) => s.senderName) ?? '익명';
+
   const { data, isLoading, isError, refetch } = useLetterDetail(letterId);
 
-  // SenderName 불러오기
-  const location = useLocation();
-  const senderName = (location.state as { senderName?: string } | null)?.senderName ?? '익명';
   const { openModal } = useModalStore();
 
   const view = useMemo<ReplyData | null>(() => {
@@ -96,14 +97,12 @@ export default function LetterReplyPage() {
   };
 
   const handleReply = () => {
-    navigate('/letter/other/draft', {
-      state: { senderName },
-    });
+    navigate('/letter/other/draft');
   };
 
   const handleEnd = () => {
     openModal('conversationRemaining', {
-      friendName: '파란수박',
+      friendName: senderName,
       remainingCount: 4,
       onContinueConversation: () => {
         // 그냥 닫히고 계속 작성
@@ -111,7 +110,7 @@ export default function LetterReplyPage() {
       onStopConversation: () => {
         // other-stop 페이지로 이동
         navigate('/letter/other-stop', {
-          state: { friendName: '파란수박', totalCount: 7 },
+          state: { friendName: senderName, totalCount: 7 },
         });
       },
     });

--- a/src/pages/letter/LetterReplyPage.tsx
+++ b/src/pages/letter/LetterReplyPage.tsx
@@ -111,7 +111,7 @@ export default function LetterReplyPage() {
   };
 
   const content = isLoading ? (
-    <div className='flex flex-col items-center justify-center gap-8 py-50'>
+    <div className='flex flex-col items-center justify-center gap-8 py-70'>
       <LoadingDots fillIntervalMs={350} />
       <p className='ty-title2'>로딩 중...</p>
     </div>

--- a/src/pages/letter/LetterReplyPage.tsx
+++ b/src/pages/letter/LetterReplyPage.tsx
@@ -72,6 +72,13 @@ export default function LetterReplyPage() {
     };
   }, [data]);
 
+  const stripQuestionPrefix = (s: string) => s.replace(/^질문\s*#\d+:\s*/, '');
+
+  const formattedQuestionTitle = useMemo(() => {
+    const q = view?.question ?? data?.question ?? '';
+    return stripQuestionPrefix(q);
+  }, [view?.question, data?.question]);
+
   const assets = useMemo(() => {
     if (!view) return null;
 
@@ -128,7 +135,7 @@ export default function LetterReplyPage() {
       <p className='ty-body5 text-[var(--color-text-normal)]'>{view.sentAtText}</p>
 
       <h1 className='mt-1 whitespace-pre-line ty-title2 leading-[140%] text-[var(--color-text-normal)]'>
-        {view.question}
+        {formattedQuestionTitle}
       </h1>
 
       {/* 편지지 컴포넌트 */}

--- a/src/pages/letter/LetterReviewPage.tsx
+++ b/src/pages/letter/LetterReviewPage.tsx
@@ -1,6 +1,5 @@
 import React, { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-// import { useParams } from 'react-router-dom'; TODO
 
 import BackHeader from '@/components/common/headers/BackHeader';
 import LetterEnvelope from '@/components/letters/LetterEnvelope';
@@ -25,7 +24,6 @@ const MOODS: Array<{
 
 export default function LetterReviewPage() {
   const navigate = useNavigate();
-  //   const { letterId } = useParams<{ letterId: string }>(); TODO
 
   const [mood, setMood] = useState<ReviewMood | null>(null);
   const [temp, setTemp] = useState<number>(0);

--- a/src/pages/letter/LetterSendingPage.tsx
+++ b/src/pages/letter/LetterSendingPage.tsx
@@ -20,6 +20,7 @@ const LetterSendingPage = () => {
   // SenderName 불러오기
   const location = useLocation();
   const senderName = (location.state as { senderName?: string } | null)?.senderName ?? '익명';
+  const friendName = (location.state as { friendName?: string } | null)?.friendName ?? '친구';
 
   const { target } = useParams<{ target?: string }>();
   // 중복 POST 방지용
@@ -149,12 +150,21 @@ const LetterSendingPage = () => {
     // TODO : Mock data 제거
     const sender = '개굴';
 
-    if (safeMode === 'anon' || safeMode === 'other') {
+    if (safeMode === 'anon') {
       return (
         <>
           {sender}님의 소중한 편지가
           <br />
           누군가에게 전달되고 있어요.
+        </>
+      );
+    }
+    if (safeMode === 'other') {
+      return (
+        <>
+          {sender}님의 소중한 편지가
+          <br />
+          {senderName}님에게 전달되고 있어요.
         </>
       );
     }
@@ -172,7 +182,7 @@ const LetterSendingPage = () => {
         <>
           {sender}님의 소중한 편지가
           <br />
-          {senderName}님에게 전달되고 있어요.
+          {friendName}님에게 전달되고 있어요.
         </>
       );
     }

--- a/src/pages/letter/LetterSendingPage.tsx
+++ b/src/pages/letter/LetterSendingPage.tsx
@@ -9,6 +9,7 @@ import { useLetterStyleOptions } from '@/hooks/letters/useLetterStyleOptions';
 import { PAPER_ASSET_MAP, DEFAULT_PAPER_ID } from '@/constants/paperAssets';
 import { useCreateSelfLetter } from '@/hooks/letters/useCreateSelfLetter';
 import { useThreadFlowStore } from '@/stores/letterContext';
+import NotFoundPage from '../system/NotFoundPage';
 
 type Target = 'anon' | 'other' | 'self' | 'friend';
 
@@ -19,7 +20,7 @@ const LetterSendingPage = () => {
   const navigate = useNavigate();
 
   const senderName = useThreadFlowStore((s) => s.senderName) ?? '익명';
-  const threadId = useThreadFlowStore((s) => s.threadId) ?? 0;
+  const threadId = useThreadFlowStore((s) => s.threadId);
 
   const { target } = useParams<{ target?: string }>();
   // 중복 POST 방지용
@@ -91,21 +92,6 @@ const LetterSendingPage = () => {
     return { ...basePayload, scheduledAt: scheduled };
   }, [basePayload, safeMode, draft.deliverAtDate]);
 
-  // 잘못된 접근 방어 (URL로 직접 접근, 꾸미기/작성 흐름 없이 들어온 경우)
-  useEffect(() => {
-    if (!safeMode) {
-      navigate('/error/404', { replace: true });
-      return;
-    }
-
-    const ok = safeMode === 'self' ? selfPayload != null : sendPayload != null;
-    // 테스트용으로 무조건 sent-transition으로 이동
-    // TODO : 기존에는 /home/main, letterCount 10회 확인 로직 추가 필요
-    if (!ok) {
-      navigate('/home/main', { replace: true });
-    }
-  }, [safeMode, selfPayload, sendPayload, navigate]);
-
   // POST 실행
   useEffect(() => {
     if (!safeMode) return;
@@ -146,7 +132,16 @@ const LetterSendingPage = () => {
     createSelfLetterMutation,
     navigate,
     showToast,
+    threadId,
   ]);
+
+  // 잘못된 접근 방어 (URL로 직접 접근, 꾸미기/작성 흐름 없이 들어온 경우)
+  const needsThreadId = safeMode === 'other';
+  const invalid = !safeMode || (needsThreadId && !threadId);
+
+  if (invalid) {
+    return <NotFoundPage />;
+  }
 
   const getTargetText = () => {
     // TODO : Mock data 제거

--- a/src/pages/letter/LetterSendingPage.tsx
+++ b/src/pages/letter/LetterSendingPage.tsx
@@ -1,5 +1,5 @@
 import LetterEnvelope from '@/components/letters/LetterEnvelope';
-import { useLocation, useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 
 import { useEffect, useMemo, useRef } from 'react';
 import { useLetterStore } from '@/stores/letterStore';
@@ -8,6 +8,7 @@ import { useGlobalToast } from '@/components/toast/ToastProvider';
 import { useLetterStyleOptions } from '@/hooks/letters/useLetterStyleOptions';
 import { PAPER_ASSET_MAP, DEFAULT_PAPER_ID } from '@/constants/paperAssets';
 import { useCreateSelfLetter } from '@/hooks/letters/useCreateSelfLetter';
+import { useThreadFlowStore } from '@/stores/letterContext';
 
 type Target = 'anon' | 'other' | 'self' | 'friend';
 
@@ -17,10 +18,8 @@ const LetterSendingPage = () => {
 
   const navigate = useNavigate();
 
-  // SenderName 불러오기
-  const location = useLocation();
-  const senderName = (location.state as { senderName?: string } | null)?.senderName ?? '익명';
-  const friendName = (location.state as { friendName?: string } | null)?.friendName ?? '친구';
+  const senderName = useThreadFlowStore((s) => s.senderName) ?? '익명';
+  const threadId = useThreadFlowStore((s) => s.threadId) ?? 0;
 
   const { target } = useParams<{ target?: string }>();
   // 중복 POST 방지용
@@ -100,7 +99,8 @@ const LetterSendingPage = () => {
     }
 
     const ok = safeMode === 'self' ? selfPayload != null : sendPayload != null;
-
+    // 테스트용으로 무조건 sent-transition으로 이동
+    // TODO : 기존에는 /home/main, letterCount 10회 확인 로직 추가 필요
     if (!ok) {
       navigate('/home/main', { replace: true });
     }
@@ -126,10 +126,12 @@ const LetterSendingPage = () => {
 
         console.log('[CreateLetter success response]', res);
 
-        navigate('/home/main', {
-          replace: true,
-          state: { toast: { status: 'success', message: '편지를 전송했어요!' } },
-        });
+        // ✅ 테스트: 성공하면 무조건 transition
+        navigate(`/friend/sent-transition/${threadId}`, { replace: true });
+        // navigate('/home/main', {
+        //   replace: true,
+        //   state: { toast: { status: 'success', message: '편지를 전송했어요!' } },
+        // });
       } catch {
         hasSentRef.current = false;
         showToast('편지 전송에 실패했어요.', 'error');
@@ -182,7 +184,7 @@ const LetterSendingPage = () => {
         <>
           {sender}님의 소중한 편지가
           <br />
-          {friendName}님에게 전달되고 있어요.
+          {senderName}님에게 전달되고 있어요.
         </>
       );
     }

--- a/src/pages/letter/OtherDraftPage.tsx
+++ b/src/pages/letter/OtherDraftPage.tsx
@@ -84,7 +84,7 @@ const OtherDraftPage = () => {
 
     patchDraft({ questionId });
 
-    navigate('/letter/anon/decorate');
+    navigate('/letter/other/decorate');
   };
 
   const handleBack = () => {

--- a/src/pages/letter/OtherDraftPage.tsx
+++ b/src/pages/letter/OtherDraftPage.tsx
@@ -13,11 +13,7 @@ import { useEffect } from 'react';
 import LoadingPage from '../system/LoadingPage';
 import { Button } from '@/components/common/Button';
 import { useThreadFlowStore } from '@/stores/letterContext';
-
-const LIMIT = {
-  TITLE: { MIN: 3, MAX: 20 },
-  CONTENT: { MIN: 1, MAX: 500 },
-} as const;
+import { validateLetter } from '@/utils/validateLetter';
 
 const OtherDraftPage = () => {
   const { data, isLoading, isError, refetch } = useDailyQuestion();
@@ -39,17 +35,6 @@ const OtherDraftPage = () => {
 
   // TODO : 남은 편지 횟수 처리 필요
   const letterLeft = 4;
-
-  const validate = (title: string, content: string) => {
-    if (title.length < LIMIT.TITLE.MIN) return `제목을 ${LIMIT.TITLE.MIN}자 이상 입력해주세요.`;
-    if (title.length > LIMIT.TITLE.MAX)
-      return `제목은 최대 ${LIMIT.TITLE.MAX}자까지 입력할 수 있어요.`;
-    if (content.length < LIMIT.CONTENT.MIN) return '내용을 작성해 주세요!';
-    if (content.length > LIMIT.CONTENT.MAX)
-      return `내용은 최대 ${LIMIT.CONTENT.MAX}자까지 입력할 수 있어요.`;
-
-    return null;
-  };
 
   // questionId 저장
   useEffect(() => {
@@ -75,7 +60,7 @@ const OtherDraftPage = () => {
 
     const title = draft.title.trim();
     const content = draft.content.trim();
-    const errorMsg = validate(title, content);
+    const errorMsg = validateLetter(title, content);
 
     if (errorMsg) {
       showToast(errorMsg, 'error');

--- a/src/pages/letter/OtherDraftPage.tsx
+++ b/src/pages/letter/OtherDraftPage.tsx
@@ -1,4 +1,4 @@
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
 import BackHeader from '@/components/common/headers/BackHeader';
 import ToggleSwitch from '@/components/common/ToggleSwitch';
@@ -12,6 +12,7 @@ import { useGlobalToast } from '@/components/toast/ToastProvider';
 import { useEffect } from 'react';
 import LoadingPage from '../system/LoadingPage';
 import { Button } from '@/components/common/Button';
+import { useThreadFlowStore } from '@/stores/letterContext';
 
 const LIMIT = {
   TITLE: { MIN: 3, MAX: 20 },
@@ -34,8 +35,7 @@ const OtherDraftPage = () => {
   }, [setActiveTarget]);
 
   // SenderName 불러오기
-  const location = useLocation();
-  const senderName = (location.state as { senderName?: string } | null)?.senderName ?? '익명';
+  const senderName = useThreadFlowStore((s) => s.senderName) ?? '익명';
 
   // TODO : 남은 편지 횟수 처리 필요
   const letterLeft = 4;

--- a/src/pages/letter/SelfDraftPage.tsx
+++ b/src/pages/letter/SelfDraftPage.tsx
@@ -14,13 +14,9 @@ import { useGlobalToast } from '@/components/toast/ToastProvider';
 import { useLetterStore } from '@/stores/letterStore';
 import { useDailyQuestion } from '@/hooks/letters/useDailyQuestion';
 import LoadingPage from '../system/LoadingPage';
+import { validateLetter } from '@/utils/validateLetter';
 
 type DateValue = { year: number; month: number; day: number };
-
-const LIMIT = {
-  TITLE: { MIN: 3, MAX: 20 },
-  CONTENT: { MIN: 1, MAX: 500 },
-} as const;
 
 const SelfDraftPage = () => {
   const { data, isLoading, isError, error } = useDailyQuestion();
@@ -147,21 +143,10 @@ const SelfDraftPage = () => {
     });
   };
 
-  const validate = (title: string, content: string) => {
-    if (title.length < LIMIT.TITLE.MIN) return `제목을 ${LIMIT.TITLE.MIN}자 이상 입력해주세요.`;
-    if (title.length > LIMIT.TITLE.MAX)
-      return `제목은 최대 ${LIMIT.TITLE.MAX}자까지 입력할 수 있어요.`;
-    if (content.length < LIMIT.CONTENT.MIN) return '내용을 작성해 주세요!';
-    if (content.length > LIMIT.CONTENT.MAX)
-      return `내용은 최대 ${LIMIT.CONTENT.MAX}자까지 입력할 수 있어요.`;
-
-    return null;
-  };
-
   const handleSubmit = () => {
     const title = draft.title.trim();
     const content = draft.content.trim();
-    const errorMsg = validate(title, content);
+    const errorMsg = validateLetter(title, content);
 
     if (errorMsg) {
       showToast(errorMsg, 'error');

--- a/src/stores/letterContext.ts
+++ b/src/stores/letterContext.ts
@@ -1,0 +1,35 @@
+import { create } from 'zustand';
+import type { Target } from './letterStore';
+
+type ThreadFlow = {
+  target: Target | null;
+
+  // 한 사람과의 대화방(세션/스레드) 식별자
+  // 근데 백엔드 코드에 의하면 receiverUserId와 같다.
+  threadId: number | null;
+
+  // UI 표시용
+  friendName: string | null; // friend 모드에서 상대 이름
+  senderName: string | null; // other/anon에서 보여줄 상대 이름
+
+  // 필요하면 나중에 추가
+  // lastLetterId?: number | null;
+  // letterCount?: number | null;
+
+  setFlow: (partial: Partial<Omit<ThreadFlow, 'setFlow' | 'resetFlow'>>) => void;
+  resetFlow: () => void;
+};
+
+const initialState = {
+  target: null,
+  threadId: null,
+  friendName: null,
+  senderName: null, // 나
+};
+
+export const useThreadFlowStore = create<ThreadFlow>((set) => ({
+  ...initialState,
+
+  setFlow: (partial) => set((s) => ({ ...s, ...partial })),
+  resetFlow: () => set(initialState),
+}));

--- a/src/stores/letterStore.ts
+++ b/src/stores/letterStore.ts
@@ -32,7 +32,7 @@ const createInitialDraft = (): LetterDraft => ({
 
 const createInitialStyle = (): LetterStyle => ({
   paperId: DEFAULT_PAPER_ID,
-  stampId: null, // TODO : AssetUrl 연동 후 초기값 정의
+  stampId: 0,
   fontId: DEFAULT_FONT_ID,
 });
 

--- a/src/types/dto/friend.ts
+++ b/src/types/dto/friend.ts
@@ -1,4 +1,4 @@
-import type { CommonResponse } from './common';
+import type { CommonResponse } from '../common';
 
 export type FriendApiResponse<T> = CommonResponse<{
   message: string;

--- a/src/types/dto/friend.ts
+++ b/src/types/dto/friend.ts
@@ -5,14 +5,20 @@ export type FriendApiResponse<T> = CommonResponse<{
   result: { data: T };
 }>;
 
+export type RecentLetter = {
+  createdAt: string;
+  design: {
+    paper?: { color?: string };
+    stamp?: { name?: string; assetUrl?: string };
+  };
+};
+
 export type FriendItem = {
   id: number;
   friendUserId: number;
   nickname: string;
   letterCount: number;
-  recentLetter: boolean;
-  createdAt: string;
-  design: Record<string, unknown>;
+  recentLetter: RecentLetter;
 };
 
 export type FriendRequestStatus = 'PENDING' | 'REJECTED' | 'DELETED';

--- a/src/types/dto/friend.ts
+++ b/src/types/dto/friend.ts
@@ -18,7 +18,7 @@ export type FriendItem = {
   friendUserId: number;
   nickname: string;
   letterCount: number;
-  recentLetter: RecentLetter;
+  recentLetter: RecentLetter | null;
 };
 
 export type FriendRequestStatus = 'PENDING' | 'REJECTED' | 'DELETED';

--- a/src/types/dto/friend.ts
+++ b/src/types/dto/friend.ts
@@ -8,8 +8,8 @@ export type FriendApiResponse<T> = CommonResponse<{
 export type RecentLetter = {
   createdAt: string;
   design: {
-    paper?: { color?: string };
-    stamp?: { name?: string; assetUrl?: string };
+    paper: { id: number; color: string };
+    stamp: { id: number; name: string; assetUrl: string };
   };
 };
 

--- a/src/types/dto/friend.ts
+++ b/src/types/dto/friend.ts
@@ -1,4 +1,4 @@
-import type { CommonResponse } from '../common';
+import type { CommonResponse } from './common';
 
 export type FriendApiResponse<T> = CommonResponse<{
   message: string;

--- a/src/types/dto/letters/sendLetter.ts
+++ b/src/types/dto/letters/sendLetter.ts
@@ -9,7 +9,7 @@ type BaseCreateLetterBody = {
 };
 
 export type CreateLetterBody = BaseCreateLetterBody & {
-  receiverUserId?: number; // friend에서만 들어감
+  receiverUserId?: number;
 };
 
 export type CreateSelfLetterBody = BaseCreateLetterBody & {

--- a/src/types/dto/mails/anonMailbox.ts
+++ b/src/types/dto/mails/anonMailbox.ts
@@ -1,18 +1,32 @@
 import type { ApiError } from '../common';
 
-export type AnonMailboxSuccess = {
-  letters: {
-    threadId: number;
-    sender: {
+export type AnonMailboxLetter = {
+  threadId: number;
+
+  sender: {
+    id: number;
+    nickname: string;
+  };
+
+  lastLetterId: number;
+  lastLetterTitle: string;
+  lastLetterPreview: string;
+  deliveredAt: string;
+
+  // design도 paper만 옴 (stamp는 별도 필드)
+  design: {
+    paper: {
       id: number;
-      nickname: string;
+      name: string;
     };
-    lastLetterId: number;
-    lastLetterTitle: string;
-    lastLetterPreview: string;
-    updatedAt: string;
-    paperId: number;
-  }[];
+  };
+
+  stampId: number;
+  stampUrl: string;
+};
+
+export type AnonMailboxSuccess = {
+  letters: AnonMailboxLetter[];
 };
 
 export type AnonMailboxResponse = {

--- a/src/types/dto/mails/anonThread.ts
+++ b/src/types/dto/mails/anonThread.ts
@@ -1,23 +1,19 @@
 import type { ApiError } from '../common';
 
+export type AnonThreadLetter = {
+  id: number;
+  title: string;
+  deliveredAt: string;
+  isMine: boolean;
+
+  paperId: number;
+  stampId: number;
+  stampUrl: string;
+};
+
 export type AnonThreadSuccess = {
   firstQuestion: string;
-  letters: {
-    id: number;
-    title: string;
-    deliveredAt: string;
-    design: {
-      paper: {
-        id: number;
-        name: string;
-      };
-      stamp: {
-        id: number;
-        name: string;
-        assetUrl: string;
-      };
-    };
-  }[];
+  letters: AnonThreadLetter[];
 };
 
 export type AnonThreadResponse = {

--- a/src/types/dto/mails/friendThread.ts
+++ b/src/types/dto/mails/friendThread.ts
@@ -1,0 +1,56 @@
+import type { ApiError } from '../common';
+
+// design
+export type PaperDesign = {
+  id: number;
+  color: string;
+  assetUrl: string;
+};
+
+export type StampDesign = {
+  id: number;
+  name: string;
+  assetUrl: string;
+};
+
+export type LetterDesign = {
+  paper: PaperDesign;
+  stamp: StampDesign;
+};
+
+// 친구가 보낸 편지
+export type FriendLetterItem = {
+  id: number;
+  title: string;
+  deliveredAt: string;
+  readAt: string | null;
+  design: LetterDesign;
+};
+
+// 사용자가 보낸 편지
+export type UserLetterItem = {
+  id: number;
+  title: string;
+  deliveredAt: string;
+  readAt: string | null;
+  question: {
+    content: string;
+  };
+  design: LetterDesign;
+};
+
+// 최종 응답
+export type FriendThreadSuccess = {
+  friendName: string;
+  firstQuestion: string;
+
+  friendLetters: FriendLetterItem[];
+
+  userLetters: UserLetterItem[];
+};
+
+export type FriendThreadResponse = {
+  resultType: 'SUCCESS' | 'FAIL';
+  error: ApiError | null;
+  success: FriendThreadSuccess | null;
+};

--- a/src/types/dto/mails/selfMailbox.ts
+++ b/src/types/dto/mails/selfMailbox.ts
@@ -1,11 +1,14 @@
 import type { ApiError } from '../common';
 
 export type SelfMailboxSuccess = {
-  items: {
+  letters: {
     id: number;
+    questionId: number;
     title: string;
     createdAt: string;
     paperId: number;
+    stampId: number;
+    stampUrl: string;
   }[];
 };
 

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,0 +1,17 @@
+export function getNowKSTIsoString(): string {
+  const now = new Date();
+
+  const KST_OFFSET_MINUTES = 9 * 60;
+  const localOffsetMinutes = now.getTimezoneOffset();
+
+  const kstTime = new Date(now.getTime() + (localOffsetMinutes + KST_OFFSET_MINUTES) * 60 * 1000);
+
+  const yyyy = kstTime.getFullYear();
+  const mm = String(kstTime.getMonth() + 1).padStart(2, '0');
+  const dd = String(kstTime.getDate()).padStart(2, '0');
+  const hh = String(kstTime.getHours()).padStart(2, '0');
+  const min = String(kstTime.getMinutes()).padStart(2, '0');
+  const ss = String(kstTime.getSeconds()).padStart(2, '0');
+
+  return `${yyyy}-${mm}-${dd}T${hh}:${min}:${ss}+09:00`;
+}

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,3 +1,4 @@
+// 백엔드에 요청용
 export function getNowKSTIsoString(): string {
   const now = new Date();
 
@@ -14,4 +15,10 @@ export function getNowKSTIsoString(): string {
   const ss = String(kstTime.getSeconds()).padStart(2, '0');
 
   return `${yyyy}-${mm}-${dd}T${hh}:${min}:${ss}+09:00`;
+}
+
+// 프론트 쿼리키용
+export function getTodayKstKey(): string {
+  const kstIso = getNowKSTIsoString(); // ...+09:00
+  return kstIso.slice(0, 10); // "YYYY-MM-DD"
 }

--- a/src/utils/validateLetter.ts
+++ b/src/utils/validateLetter.ts
@@ -1,0 +1,15 @@
+const LIMIT = {
+  TITLE: { MIN: 3, MAX: 20 },
+  CONTENT: { MIN: 1, MAX: 500 },
+} as const;
+
+export const validateLetter = (title: string, content: string) => {
+  if (title.length < LIMIT.TITLE.MIN) return `제목을 ${LIMIT.TITLE.MIN}자 이상 입력해주세요.`;
+  if (title.length > LIMIT.TITLE.MAX)
+    return `제목은 최대 ${LIMIT.TITLE.MAX}자까지 입력할 수 있어요.`;
+  if (content.length < LIMIT.CONTENT.MIN) return '내용을 작성해 주세요!';
+  if (content.length > LIMIT.CONTENT.MAX)
+    return `내용은 최대 ${LIMIT.CONTENT.MAX}자까지 입력할 수 있어요.`;
+
+  return null;
+};


### PR DESCRIPTION
## 📂 관련 이슈

- closes #110 

---

## 🛠️ 작업 사항

- [x] 친구탭 -> 목록 GET -> 스레드 GET (스레드 GET만 연동하면 됨) 
- [x] 상세 조회 연동 유무 확인
- [x] 스레드 GET -> 편지 상세 조회 -> friend-draft 페이지 연동
- [x] receiverUserId 정보 언제 갖는지 확인 (친구 수락?)
- [x] friend-draft에서 receiverUserId 추가해서 POST

---

## 📸 관련 이미지 (스크린샷 또는 동영상)

---

## 💬 기타 설명

> 백엔드 측에서 테스트 데이터 확정 후, 필수/선택 필드 픽스 필요. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리즈 노트

* **새로운 기능**
  * 친구 스레드 기반 편지 조회·답장 페이지 추가
  * 친구 대화(스레드)에서 편지 목록·상세 보기 및 답장 작성 지원
  * 편지 작성 시 동적 일일 질문 노출
  * 우편봉투 미리보기·우표 이미지 표시 및 스탬프 정보 노출

* **개선 사항**
  * 편지 작성 흐름 검증(제목/본문 길이) 및 사용자 안내 강화
  * 친구·편지 네비게이션을 스레드 중심으로 정비하여 이동성 향상
<!-- end of auto-generated comment: release notes by coderabbit.ai -->