### PR TITLE
[Feat] 로그아웃/회원탈퇴 API 연동

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -57,7 +57,7 @@ export const postSignin = async (body: SignInRequest) => {
 };
 /**
  * 로그아웃 API
- * POST /auth/logou
+ * POST /auth/logout
  */
 export const postLogout = async () => {
   // 로그아웃은 보통 Body({})가 비어있어도 됩니다.

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -14,6 +14,8 @@ import type {
   SocialLoginResponse,
   UsernameExistsRequest,
   UsernameExistsResponse,
+  WithdrawResponse,
+  WithdrawResult,
 } from '@/types/dto/auth';
 import { axiosInstance } from './axios'; // axios 설정 파일 경로
 
@@ -60,6 +62,15 @@ export const postSignin = async (body: SignInRequest) => {
 export const postLogout = async () => {
   // 로그아웃은 보통 Body({})가 비어있어도 됩니다.
   const { data } = await axiosInstance.post<LogoutResponse>('/auth/logout');
+  return data;
+};
+
+/**
+ * 회원탈퇴 API
+ * DELETE /users
+ */
+export const deleteWithdraw = async () => {
+  const { data } = await axiosInstance.delete<WithdrawResponse>('/users');
   return data;
 };
 /**

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -3,6 +3,7 @@ import type {
   AgreementsResponse,
   EmailExistsRequest,
   EmailExistsResponse,
+  LogoutResponse,
   NicknameSetUpRequest,
   NicknameSetUpResponse,
   ProfileImageResponse,
@@ -52,7 +53,15 @@ export const postSignin = async (body: SignInRequest) => {
   const { data } = await axiosInstance.post<SignInResponse>('/auth/login', body);
   return data;
 };
-
+/**
+ * 로그아웃 API
+ * POST /auth/logou
+ */
+export const postLogout = async () => {
+  // 로그아웃은 보통 Body({})가 비어있어도 됩니다.
+  const { data } = await axiosInstance.post<LogoutResponse>('/auth/logout');
+  return data;
+};
 /**
  * 소셜 로그인 (인가 코드 -> 토큰 교환)
  * @param provider 'google' | 'kakao' | 'naver'

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -57,91 +57,93 @@ axiosInstance.interceptors.response.use(
 
     const { logout, login } = useAuthStore.getState();
 
-    if (error.response) {
-      const { status } = error.response;
+    if (!error.response) {
+      return Promise.reject(error);
+    }
+    const { status } = error.response;
+    //  401 에러 처리 로직
+    if (status !== 401) {
+      return Promise.reject(error);
+    }
+    // Case A: 리프레시 요청 자체가 401이 뜬 경우 (갱신 요청 실패 -> 강제 로그아웃)
+    // -> 자동으로 스플래쉬으로 쫓아냄
+    if (originalRequest.url?.includes('/auth/refresh')) {
+      isRefreshing = false;
 
-      //  401 에러 처리 로직
-      if (status === 401) {
-        // Case A: 리프레시 요청 자체가 401이 뜬 경우 (갱신 요청 실패 -> 강제 로그아웃)
-        // -> 자동으로 스플래쉬으로 쫓아냄
-        if (originalRequest.url?.includes('/auth/refresh')) {
-          isRefreshing = false;
+      logout();
 
-          logout();
+      onRefreshFailed(error);
+      return Promise.reject(error);
+    }
+    // 무한 루프 방지
+    if (originalRequest._retry) {
+      return Promise.reject(error);
+    }
 
-          onRefreshFailed(error);
-        }
-        return Promise.reject(error);
-      }
-      if (originalRequest._retry) {
-        return Promise.reject(error);
-      }
-
-      // Case B: 이미 다른 요청이 리프레시를 하고 있는 경우
-      // -> 대기열(subscribers)에 줄 서게 함 (동시성 제어)
-      if (isRefreshing) {
-        return new Promise((resolve, reject) => {
-          refreshSubscribers.push({
-            resolve: (token: string) => {
-              originalRequest.headers.Authorization = `Bearer ${token}`;
-              resolve(axiosInstance(originalRequest));
-            },
-            reject,
-          });
-        });
-      }
-
-      // Case C: 토큰 만료 후 첫 401 발생 (갱신 시도)
-      originalRequest._retry = true; // 무한루프 방지용 플래그
-      isRefreshing = true;
-
-      try {
-        const storedRefreshToken = localStorage.getItem('refreshToken');
-        // 토큰이 없으면 로그아웃 처리
-        if (!storedRefreshToken) {
-          throw new Error('No Refresh Token');
-        }
-
-        // 2. 헤더에 리프레시 토큰을 담아서 요청
-        const { data } = await axios.get<RefreshTokenResponse>(`${baseURL}/auth/refresh`, {
-          withCredentials: true,
-          headers: {
-            // 여기서 AccessToken 대신 RefreshToken을 꽂아서 보냄
-            Authorization: `Bearer ${storedRefreshToken}`,
+    // Case B: 이미 다른 요청이 리프레시를 하고 있는 경우
+    // -> 대기열(subscribers)에 줄 서게 함 (동시성 제어)
+    if (isRefreshing) {
+      return new Promise((resolve, reject) => {
+        refreshSubscribers.push({
+          resolve: (token: string) => {
+            originalRequest.headers.Authorization = `Bearer ${token}`;
+            resolve(axiosInstance(originalRequest));
           },
+          reject,
         });
+      });
+    }
 
-        // 성공 시 로직
-        if (data.resultType === 'SUCCESS' && data.success) {
-          const newAccessToken = data.success.jwtAccessToken;
+    // Case C: 토큰 만료 후 첫 401 발생 (갱신 시도)
+    originalRequest._retry = true; // 무한루프 방지용 플래그
+    isRefreshing = true;
 
-          // 1. 새 토큰 저장
-
-          // 토큰이 갱신됐을 때도 스토어 업데이트 (일관성 유지)
-          // RefreshToken은 그대로라면 가져와서 다시 넣어줌
-          const currentRefreshToken = localStorage.getItem('refreshToken') || '';
-          login(newAccessToken, currentRefreshToken);
-          // 2. 대기열 해소 (기다리던 요청들 재실행)
-          isRefreshing = false;
-          onRefreshed(newAccessToken);
-
-          // 3. 현재 실패했던 요청 헤더 갈아끼우고 재실행
-          originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
-          return axiosInstance(originalRequest);
-        } else {
-          // [수정 2] 200 OK지만 비즈니스 로직상 실패(FAIL)인 경우 -> 로그아웃 처리
-          // 이걸 안 하면 isRefreshing이 true로 남아서 무한 대기 걸림
-          logout();
-          throw new Error('Refresh Token Invalid');
-        }
-      } catch (refreshError) {
-        // 갱신 실패 시 (네트워크 에러 or 위에서 throw한 에러) -> 스플래쉬으로 이동
-        isRefreshing = false; // [중요] 상태 초기화
-        onRefreshFailed(refreshError);
-        logout();
-
-        return Promise.reject(refreshError);
+    try {
+      const storedRefreshToken = localStorage.getItem('refreshToken');
+      // 토큰이 없으면 로그아웃 처리
+      if (!storedRefreshToken) {
+        throw new Error('No Refresh Token');
       }
+
+      // 2. 헤더에 리프레시 토큰을 담아서 요청
+      const { data } = await axios.get<RefreshTokenResponse>(`${baseURL}/auth/refresh`, {
+        withCredentials: true,
+        headers: {
+          // 여기서 AccessToken 대신 RefreshToken을 꽂아서 보냄
+          Authorization: `Bearer ${storedRefreshToken}`,
+        },
+      });
+
+      // 성공 시 로직
+      if (data.resultType === 'SUCCESS' && data.success) {
+        const newAccessToken = data.success.jwtAccessToken;
+
+        // 1. 새 토큰 저장
+
+        // 토큰이 갱신됐을 때도 스토어 업데이트 (일관성 유지)
+        // RefreshToken은 그대로라면 가져와서 다시 넣어줌
+        const currentRefreshToken = localStorage.getItem('refreshToken') || '';
+        login(newAccessToken, currentRefreshToken);
+        // 2. 대기열 해소 (기다리던 요청들 재실행)
+        isRefreshing = false;
+        onRefreshed(newAccessToken);
+
+        // 3. 현재 실패했던 요청 헤더 갈아끼우고 재실행
+        originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
+        return axiosInstance(originalRequest);
+      } else {
+        // [수정 2] 200 OK지만 비즈니스 로직상 실패(FAIL)인 경우 -> 로그아웃 처리
+        // 이걸 안 하면 isRefreshing이 true로 남아서 무한 대기 걸림
+        logout();
+        throw new Error('Refresh Token Invalid');
+      }
+    } catch (refreshError) {
+      // 갱신 실패 시 (네트워크 에러 or 위에서 throw한 에러) -> 스플래쉬으로 이동
+      isRefreshing = false; // [중요] 상태 초기화
+      onRefreshFailed(refreshError);
+      logout(); // 강제 로그아웃
+
+      return Promise.reject(refreshError);
     }
   },
 );

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -63,11 +63,10 @@ axiosInstance.interceptors.response.use(
       //  401 에러 처리 로직
       if (status === 401) {
         // Case A: 리프레시 요청 자체가 401이 뜬 경우 (갱신 요청 실패 -> 강제 로그아웃)
-        // ->  스플래쉬으로 쫓아냄
+        // -> 자동으로 스플래쉬으로 쫓아냄
         if (originalRequest.url?.includes('/auth/refresh')) {
           isRefreshing = false;
-          //localStorage.removeItem('accessToken');
-          //localStorage.removeItem('refreshToken'); //clear 대신
+
           logout();
 
           onRefreshFailed(error);
@@ -117,7 +116,7 @@ axiosInstance.interceptors.response.use(
           const newAccessToken = data.success.jwtAccessToken;
 
           // 1. 새 토큰 저장
-          //localStorage.setItem('accessToken', newAccessToken);
+
           // 토큰이 갱신됐을 때도 스토어 업데이트 (일관성 유지)
           // RefreshToken은 그대로라면 가져와서 다시 넣어줌
           const currentRefreshToken = localStorage.getItem('refreshToken') || '';
@@ -139,8 +138,6 @@ axiosInstance.interceptors.response.use(
         // 갱신 실패 시 (네트워크 에러 or 위에서 throw한 에러) -> 스플래쉬으로 이동
         isRefreshing = false; // [중요] 상태 초기화
         onRefreshFailed(refreshError);
-        //localStorage.removeItem('accessToken');
-        //localStorage.removeItem('refreshToken'); //clear 대신
         logout();
 
         return Promise.reject(refreshError);

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -63,7 +63,7 @@ axiosInstance.interceptors.response.use(
       //  401 에러 처리 로직
       if (status === 401) {
         // Case A: 리프레시 요청 자체가 401이 뜬 경우 (갱신 요청 실패 -> 강제 로그아웃)
-        // ->  온보딩으로 쫓아냄
+        // ->  스플래쉬으로 쫓아냄
         if (originalRequest.url?.includes('/auth/refresh')) {
           isRefreshing = false;
           //localStorage.removeItem('accessToken');
@@ -71,89 +71,80 @@ axiosInstance.interceptors.response.use(
           logout();
 
           onRefreshFailed(error);
-          if (window.location.pathname !== '/onboarding') {
-            window.location.href = '/onboarding'; //navigate로 또는 보통은 logout()이 실행되면 App.tsx에서 감지해서 쫓아내는
-          }
-          return Promise.reject(error);
         }
-        if (originalRequest._retry) {
-          return Promise.reject(error);
-        }
+        return Promise.reject(error);
+      }
+      if (originalRequest._retry) {
+        return Promise.reject(error);
+      }
 
-        // Case B: 이미 다른 요청이 리프레시를 하고 있는 경우
-        // -> 대기열(subscribers)에 줄 서게 함 (동시성 제어)
-        if (isRefreshing) {
-          return new Promise((resolve, reject) => {
-            refreshSubscribers.push({
-              resolve: (token: string) => {
-                originalRequest.headers.Authorization = `Bearer ${token}`;
-                resolve(axiosInstance(originalRequest));
-              },
-              reject,
-            });
-          });
-        }
-
-        // Case C: 토큰 만료 후 첫 401 발생 (갱신 시도)
-        originalRequest._retry = true; // 무한루프 방지용 플래그
-        isRefreshing = true;
-
-        try {
-          const storedRefreshToken = localStorage.getItem('refreshToken');
-          // 토큰이 없으면 로그아웃 처리
-          if (!storedRefreshToken) {
-            throw new Error('No Refresh Token');
-          }
-
-          // 2. 헤더에 리프레시 토큰을 담아서 요청
-          const { data } = await axios.get<RefreshTokenResponse>(`${baseURL}/auth/refresh`, {
-            withCredentials: true,
-            headers: {
-              // 여기서 AccessToken 대신 RefreshToken을 꽂아서 보냄
-              Authorization: `Bearer ${storedRefreshToken}`,
+      // Case B: 이미 다른 요청이 리프레시를 하고 있는 경우
+      // -> 대기열(subscribers)에 줄 서게 함 (동시성 제어)
+      if (isRefreshing) {
+        return new Promise((resolve, reject) => {
+          refreshSubscribers.push({
+            resolve: (token: string) => {
+              originalRequest.headers.Authorization = `Bearer ${token}`;
+              resolve(axiosInstance(originalRequest));
             },
+            reject,
           });
+        });
+      }
 
-          // 성공 시 로직
-          if (data.resultType === 'SUCCESS' && data.success) {
-            const newAccessToken = data.success.jwtAccessToken;
+      // Case C: 토큰 만료 후 첫 401 발생 (갱신 시도)
+      originalRequest._retry = true; // 무한루프 방지용 플래그
+      isRefreshing = true;
 
-            // 1. 새 토큰 저장
-            //localStorage.setItem('accessToken', newAccessToken);
-            // 토큰이 갱신됐을 때도 스토어 업데이트 (일관성 유지)
-            // RefreshToken은 그대로라면 가져와서 다시 넣어줌
-            const currentRefreshToken = localStorage.getItem('refreshToken') || '';
-            login(newAccessToken, currentRefreshToken);
-            // 2. 대기열 해소 (기다리던 요청들 재실행)
-            isRefreshing = false;
-            onRefreshed(newAccessToken);
-
-            // 3. 현재 실패했던 요청 헤더 갈아끼우고 재실행
-            originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
-            return axiosInstance(originalRequest);
-          } else {
-            // [수정 2] 200 OK지만 비즈니스 로직상 실패(FAIL)인 경우 -> 로그아웃 처리
-            // 이걸 안 하면 isRefreshing이 true로 남아서 무한 대기 걸림
-            logout();
-            throw new Error('Refresh Token Invalid');
-          }
-        } catch (refreshError) {
-          // 갱신 실패 시 (네트워크 에러 or 위에서 throw한 에러) -> [기존 코드]처럼 온보딩으로 이동
-          isRefreshing = false; // [중요] 상태 초기화
-          onRefreshFailed(refreshError);
-          //localStorage.removeItem('accessToken');
-          //localStorage.removeItem('refreshToken'); //clear 대신
-          logout();
-
-          if (window.location.pathname !== '/onboarding') {
-            window.location.href = '/onboarding';
-          }
-          return Promise.reject(refreshError);
+      try {
+        const storedRefreshToken = localStorage.getItem('refreshToken');
+        // 토큰이 없으면 로그아웃 처리
+        if (!storedRefreshToken) {
+          throw new Error('No Refresh Token');
         }
+
+        // 2. 헤더에 리프레시 토큰을 담아서 요청
+        const { data } = await axios.get<RefreshTokenResponse>(`${baseURL}/auth/refresh`, {
+          withCredentials: true,
+          headers: {
+            // 여기서 AccessToken 대신 RefreshToken을 꽂아서 보냄
+            Authorization: `Bearer ${storedRefreshToken}`,
+          },
+        });
+
+        // 성공 시 로직
+        if (data.resultType === 'SUCCESS' && data.success) {
+          const newAccessToken = data.success.jwtAccessToken;
+
+          // 1. 새 토큰 저장
+          //localStorage.setItem('accessToken', newAccessToken);
+          // 토큰이 갱신됐을 때도 스토어 업데이트 (일관성 유지)
+          // RefreshToken은 그대로라면 가져와서 다시 넣어줌
+          const currentRefreshToken = localStorage.getItem('refreshToken') || '';
+          login(newAccessToken, currentRefreshToken);
+          // 2. 대기열 해소 (기다리던 요청들 재실행)
+          isRefreshing = false;
+          onRefreshed(newAccessToken);
+
+          // 3. 현재 실패했던 요청 헤더 갈아끼우고 재실행
+          originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
+          return axiosInstance(originalRequest);
+        } else {
+          // [수정 2] 200 OK지만 비즈니스 로직상 실패(FAIL)인 경우 -> 로그아웃 처리
+          // 이걸 안 하면 isRefreshing이 true로 남아서 무한 대기 걸림
+          logout();
+          throw new Error('Refresh Token Invalid');
+        }
+      } catch (refreshError) {
+        // 갱신 실패 시 (네트워크 에러 or 위에서 throw한 에러) -> 스플래쉬으로 이동
+        isRefreshing = false; // [중요] 상태 초기화
+        onRefreshFailed(refreshError);
+        //localStorage.removeItem('accessToken');
+        //localStorage.removeItem('refreshToken'); //clear 대신
+        logout();
+
+        return Promise.reject(refreshError);
       }
     }
-
-    // 401 아닌 다른 에러는 그대로 반환 (기존과 동일)
-    return Promise.reject(error);
   },
 );

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -1,3 +1,4 @@
+import { useAuthStore } from '@/stores/useAuthStore';
 import type { RefreshTokenResponse } from '@/types/dto/auth';
 import axios, { AxiosError, type AxiosResponse, type InternalAxiosRequestConfig } from 'axios';
 
@@ -54,20 +55,24 @@ axiosInstance.interceptors.response.use(
     // 에러난 요청의 설정값(url, headers 등)을 가져옵니다.
     const originalRequest = error.config as InternalAxiosRequestConfig & { _retry?: boolean };
 
+    const { logout, login } = useAuthStore.getState();
+
     if (error.response) {
       const { status } = error.response;
 
       //  401 에러 처리 로직
       if (status === 401) {
-        // Case A: 리프레시 요청 자체가 401이 뜬 경우 (갱신도 실패)
-        // ->  온보딩으로 쫓아냅니다.
+        // Case A: 리프레시 요청 자체가 401이 뜬 경우 (갱신 요청 실패 -> 강제 로그아웃)
+        // ->  온보딩으로 쫓아냄
         if (originalRequest.url?.includes('/auth/refresh')) {
           isRefreshing = false;
-          localStorage.removeItem('accessToken');
-          localStorage.removeItem('refreshToken'); //clear 대신
+          //localStorage.removeItem('accessToken');
+          //localStorage.removeItem('refreshToken'); //clear 대신
+          logout();
+
           onRefreshFailed(error);
           if (window.location.pathname !== '/onboarding') {
-            window.location.href = '/onboarding';
+            window.location.href = '/onboarding'; //navigate로 또는 보통은 logout()이 실행되면 App.tsx에서 감지해서 쫓아내는
           }
           return Promise.reject(error);
         }
@@ -114,8 +119,11 @@ axiosInstance.interceptors.response.use(
             const newAccessToken = data.success.jwtAccessToken;
 
             // 1. 새 토큰 저장
-            localStorage.setItem('accessToken', newAccessToken);
-
+            //localStorage.setItem('accessToken', newAccessToken);
+            // 토큰이 갱신됐을 때도 스토어 업데이트 (일관성 유지)
+            // RefreshToken은 그대로라면 가져와서 다시 넣어줌
+            const currentRefreshToken = localStorage.getItem('refreshToken') || '';
+            login(newAccessToken, currentRefreshToken);
             // 2. 대기열 해소 (기다리던 요청들 재실행)
             isRefreshing = false;
             onRefreshed(newAccessToken);
@@ -126,14 +134,16 @@ axiosInstance.interceptors.response.use(
           } else {
             // [수정 2] 200 OK지만 비즈니스 로직상 실패(FAIL)인 경우 -> 로그아웃 처리
             // 이걸 안 하면 isRefreshing이 true로 남아서 무한 대기 걸림
+            logout();
             throw new Error('Refresh Token Invalid');
           }
         } catch (refreshError) {
           // 갱신 실패 시 (네트워크 에러 or 위에서 throw한 에러) -> [기존 코드]처럼 온보딩으로 이동
           isRefreshing = false; // [중요] 상태 초기화
           onRefreshFailed(refreshError);
-          localStorage.removeItem('accessToken');
-          localStorage.removeItem('refreshToken'); //clear 대신
+          //localStorage.removeItem('accessToken');
+          //localStorage.removeItem('refreshToken'); //clear 대신
+          logout();
 
           if (window.location.pathname !== '/onboarding') {
             window.location.href = '/onboarding';

--- a/src/hooks/useAuthHandlers.ts
+++ b/src/hooks/useAuthHandlers.ts
@@ -11,7 +11,7 @@ export const useAuthHandlers = () => {
       await postLogout(); // 서버에 "나 간다" 알림
       console.log('로그아웃성공');
     } catch (error) {
-      console.error('로그아웃 실패(토큰만료 등):', error);
+      console.error('로그아웃 실패(토큰만료 등)');
     } finally {
       // 성공하든 실패하든 클라이언트는 무조건 로그아웃 처리
       logout();
@@ -31,7 +31,7 @@ export const useAuthHandlers = () => {
       logout();
       navigate('/splash', { replace: true });
     } catch (error) {
-      console.error('회원탈퇴 실패:', error);
+      console.error('회원탈퇴 실패');
     }
   };
   return { handleLogout, handleWithdraw };

--- a/src/hooks/useAuthHandlers.ts
+++ b/src/hooks/useAuthHandlers.ts
@@ -9,6 +9,7 @@ export const useAuthHandlers = () => {
   const handleLogout = async () => {
     try {
       await postLogout(); // 서버에 "나 간다" 알림
+      console.log('로그아웃성공');
     } catch (error) {
       console.error('로그아웃 실패(토큰만료 등):', error);
     } finally {

--- a/src/hooks/useAuthHandlers.ts
+++ b/src/hooks/useAuthHandlers.ts
@@ -1,0 +1,42 @@
+import { useNavigate } from 'react-router-dom';
+import { useAuthStore } from '@/stores/useAuthStore';
+import { postLogout } from '@/api/auth'; //TODO: 회원탈퇴 API
+export const useAuthHandlers = () => {
+  const navigate = useNavigate();
+  const logout = useAuthStore((state) => state.logout);
+
+  // 1. 로그아웃 핸들러
+  const handleLogout = async () => {
+    try {
+      await postLogout(); // 서버에 "나 간다" 알림
+    } catch (error) {
+      console.error('로그아웃 실패(토큰만료 등):', error);
+    } finally {
+      // 성공하든 실패하든 클라이언트는 무조건 로그아웃 처리
+      logout();
+      navigate('/splash', { replace: true });
+    }
+  };
+
+  {
+    /*// 2. 회원탈퇴 핸들러
+  const handleWithdraw = async () => {
+    try {
+      // 회원탈퇴 API 호출
+      // await postWithdraw(); 
+      
+      console.log('회원탈퇴 성공');
+      
+      // 탈퇴 후에도 로그아웃 처리와 동일하게 청소 필요
+      logout();
+      navigate('/splash', { replace: true });
+    } catch (error) {
+      console.error('회원탈퇴 실패:', error);
+      // 에러 시 토스트 메시지 등을 띄울 수 있음
+      alert('회원탈퇴 처리에 실패했습니다. 잠시 후 다시 시도해주세요.');
+    }
+  };
+*/
+  }
+  return { handleLogout };
+};

--- a/src/hooks/useAuthHandlers.ts
+++ b/src/hooks/useAuthHandlers.ts
@@ -1,6 +1,6 @@
 import { useNavigate } from 'react-router-dom';
 import { useAuthStore } from '@/stores/useAuthStore';
-import { postLogout } from '@/api/auth'; //TODO: 회원탈퇴 API
+import { postLogout, deleteWithdraw } from '@/api/auth'; //TODO: 회원탈퇴 API
 export const useAuthHandlers = () => {
   const navigate = useNavigate();
   const logout = useAuthStore((state) => state.logout);
@@ -19,25 +19,20 @@ export const useAuthHandlers = () => {
     }
   };
 
-  {
-    /*// 2. 회원탈퇴 핸들러
+  // 2. 회원탈퇴 핸들러
   const handleWithdraw = async () => {
     try {
       // 회원탈퇴 API 호출
-      // await postWithdraw(); 
-      
+      await deleteWithdraw();
+
       console.log('회원탈퇴 성공');
-      
+
       // 탈퇴 후에도 로그아웃 처리와 동일하게 청소 필요
       logout();
       navigate('/splash', { replace: true });
     } catch (error) {
       console.error('회원탈퇴 실패:', error);
-      // 에러 시 토스트 메시지 등을 띄울 수 있음
-      alert('회원탈퇴 처리에 실패했습니다. 잠시 후 다시 시도해주세요.');
     }
   };
-*/
-  }
-  return { handleLogout };
+  return { handleLogout, handleWithdraw };
 };

--- a/src/hooks/useAuthHandlers.ts
+++ b/src/hooks/useAuthHandlers.ts
@@ -1,17 +1,18 @@
 import { useNavigate } from 'react-router-dom';
 import { useAuthStore } from '@/stores/useAuthStore';
 import { postLogout, deleteWithdraw } from '@/api/auth'; //TODO: 회원탈퇴 API
+import { useGlobalToast } from '@/components/toast/ToastProvider';
 export const useAuthHandlers = () => {
   const navigate = useNavigate();
   const logout = useAuthStore((state) => state.logout);
+  const { showToast } = useGlobalToast();
 
   // 1. 로그아웃 핸들러
   const handleLogout = async () => {
     try {
       await postLogout(); // 서버에 "나 간다" 알림
-      console.log('로그아웃성공');
     } catch (error) {
-      console.error('로그아웃 실패(토큰만료 등)');
+      showToast('로그아웃 실패했어요. 잠시 후 다시 요청해주세요.', 'error');
     } finally {
       // 성공하든 실패하든 클라이언트는 무조건 로그아웃 처리
       logout();
@@ -25,13 +26,11 @@ export const useAuthHandlers = () => {
       // 회원탈퇴 API 호출
       await deleteWithdraw();
 
-      console.log('회원탈퇴 성공');
-
       // 탈퇴 후에도 로그아웃 처리와 동일하게 청소 필요
       logout();
       navigate('/splash', { replace: true });
     } catch (error) {
-      console.error('회원탈퇴 실패');
+      showToast('회원 탈퇴에 실패했어요. 잠시 후 다시 요청해주세요.', 'error');
     }
   };
   return { handleLogout, handleWithdraw };

--- a/src/pages/login/SignInPage.tsx
+++ b/src/pages/login/SignInPage.tsx
@@ -6,10 +6,12 @@ import { blockSpaceKey, removeWhitespace } from '@/utils/inputUtils';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuthStore } from '@/stores/useAuthStore';
+import { useGlobalToast } from '@/components/toast/ToastProvider';
 
 const SignInPage = () => {
   const login = useAuthStore((state) => state.login);
   const navigate = useNavigate();
+  const { showToast } = useGlobalToast();
   // 1. DTO에 맞춰 userName으로 상태 관리
   const [username, setUserName] = useState('');
   const [password, setPassword] = useState('');
@@ -54,15 +56,15 @@ const SignInPage = () => {
         navigate('/');
       } else {
         // 200 OK지만 실패 로직 (예: 비밀번호 불일치 등 서버가 정의한 에러)
-        console.warn('[로그인 실패] 이유:', error?.reason);
+        showToast(error?.reason, 'error');
       }
     } catch (err: any) {
-      console.error(' [통신 에러]:', err);
+      showToast('통신 에러입니다.', 'error');
       if (err.response) {
         // 서버가 400, 500 등을 보냈을 때
-        console.log(err.response.data?.error?.reason || '서버 오류가 발생했습니다.');
+        showToast(err.response.data?.error?.reason || '서버 오류가 발생했습니다.', 'error');
       } else {
-        console.log('네트워크 연결을 확인해주세요.');
+        showToast('네트워크 연결을 확인해주세요.', 'error');
       }
     }
   };

--- a/src/pages/login/SignInPage.tsx
+++ b/src/pages/login/SignInPage.tsx
@@ -5,8 +5,10 @@ import type { SignInRequest, SignInResponse } from '@/types/dto/auth';
 import { blockSpaceKey, removeWhitespace } from '@/utils/inputUtils';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useAuthStore } from '@/stores/useAuthStore';
 
 const SignInPage = () => {
+  const login = useAuthStore((state) => state.login);
   const navigate = useNavigate();
   // 1. DTO에 맞춰 userName으로 상태 관리
   const [username, setUserName] = useState('');
@@ -46,9 +48,11 @@ const SignInPage = () => {
         const { jwtAccessToken, jwtRefreshToken } = success.result;
 
         // 토큰 저장
-        localStorage.setItem('accessToken', jwtAccessToken);
-        localStorage.setItem('refreshToken', jwtRefreshToken);
+        //localStorage.setItem('accessToken', jwtAccessToken);
+        //localStorage.setItem('refreshToken', jwtRefreshToken);
 
+        // (Store가 내부적으로 localStorage 저장도 하고, isLoggedIn 상태도 true로 바꿈)
+        login(jwtAccessToken);
         console.log('토큰 저장 완료! 메인으로 이동');
         navigate('/');
       } else {

--- a/src/pages/login/SignInPage.tsx
+++ b/src/pages/login/SignInPage.tsx
@@ -48,11 +48,8 @@ const SignInPage = () => {
         const { jwtAccessToken, jwtRefreshToken } = success.result;
 
         // 토큰 저장
-        //localStorage.setItem('accessToken', jwtAccessToken);
-        //localStorage.setItem('refreshToken', jwtRefreshToken);
-
         // (Store가 내부적으로 localStorage 저장도 하고, isLoggedIn 상태도 true로 바꿈)
-        login(jwtAccessToken);
+        login(jwtAccessToken, jwtRefreshToken);
         console.log('토큰 저장 완료! 메인으로 이동');
         navigate('/');
       } else {

--- a/src/pages/login/SignUpPage.tsx
+++ b/src/pages/login/SignUpPage.tsx
@@ -15,11 +15,13 @@ import useSignUpForm from '@/hooks/useSignUpForm';
 import { postSignup } from '@/api/auth';
 import type { SignUpRequest } from '@/types/dto/auth';
 import { useState } from 'react';
+import { useAuthStore } from '@/stores/useAuthStore';
 
 // Todo:
 // 1.이메일 중복시 처리
 
 const SignUpPage = () => {
+  const login = useAuthStore((state) => state.login);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const navigate = useNavigate();
 
@@ -83,11 +85,11 @@ const SignUpPage = () => {
       //  API 호출
       const response = await postSignup(requestBody);
 
-      // 결과 콘솔 출력
-      //console.log('회원가입 Response:', response);
-
       // 4. 성공 시 처리
       if (response.resultType === 'SUCCESS') {
+        const { jwtAccessToken, jwtRefreshToken } = response.success.result.tokens;
+        // 스토어에 저장 (로컬스토리지 저장 + 전역 상태 변경)
+        login(jwtAccessToken, jwtRefreshToken);
         // 성공 시 다음 페이지(프로필 설정)로 이동
         navigate('/auth/profile-setup');
       } else {

--- a/src/pages/login/SocialLoginCallBackPage.tsx
+++ b/src/pages/login/SocialLoginCallBackPage.tsx
@@ -3,9 +3,11 @@ import LoadingPage from '../system/LoadingPage';
 import { postSocialLogin, type SocialProvider } from '@/api/auth';
 import { useEffect, useRef } from 'react';
 import { ROUTES } from '@/routes/paths';
+import { useAuthStore } from '@/stores/useAuthStore';
 
 const SocialLoginCallBackPage = () => {
   const navigate = useNavigate();
+  const login = useAuthStore((state) => state.login);
   const { provider } = useParams();
   const [searchParams] = useSearchParams();
   const code = searchParams.get('code');
@@ -19,8 +21,7 @@ const SocialLoginCallBackPage = () => {
         const { isNewUser } = data.success; // isNewUser 꺼내기
         // 토큰 저장 및 이동
         const { jwtAccessToken, jwtRefreshToken } = data.success.tokens;
-        localStorage.setItem('accessToken', jwtAccessToken);
-        localStorage.setItem('refreshToken', jwtRefreshToken);
+        login(jwtAccessToken, jwtRefreshToken);
         //  신규 유저 여부에 따라 페이지 이동 분기
         if (isNewUser) {
           console.log('신규 회원입니다. 온보딩으로 이동합니다.');

--- a/src/pages/setting/SettingPage.tsx
+++ b/src/pages/setting/SettingPage.tsx
@@ -21,7 +21,7 @@ import { useAuthHandlers } from '@/hooks/useAuthHandlers';
 export default function SettingPage() {
   const navigate = useNavigate();
   const { openModal } = useModalStore();
-  const { handleLogout } = useAuthHandlers();
+  const { handleLogout, handleWithdraw } = useAuthHandlers();
 
   const handleBack = () => {
     navigate(-1);
@@ -217,7 +217,9 @@ export default function SettingPage() {
               <li>
                 <button
                   // TODO: 실제 회원탈퇴 처리 함수(onConfirmWithdraw) 연결 필요
-                  onClick={() => openModal('withdrawalConfirm')}
+                  onClick={() =>
+                    openModal('withdrawalConfirm', { onConfirmWithdraw: handleWithdraw })
+                  }
                   className='w-full text-left'
                   style={{
                     fontFamily: 'Pretendard',

--- a/src/pages/setting/SettingPage.tsx
+++ b/src/pages/setting/SettingPage.tsx
@@ -16,10 +16,12 @@ import {
   SECTION_SPACING_MEDIUM,
   SECTION_SPACING_LARGE,
 } from '@/constants/settingLayout';
+import { useAuthHandlers } from '@/hooks/useAuthHandlers';
 
 export default function SettingPage() {
   const navigate = useNavigate();
   const { openModal } = useModalStore();
+  const { handleLogout } = useAuthHandlers();
 
   const handleBack = () => {
     navigate(-1);
@@ -196,7 +198,7 @@ export default function SettingPage() {
               <li>
                 <button
                   // TODO: 실제 로그아웃 처리 함수(onConfirmLogout) 연결 필요
-                  onClick={() => openModal('logoutConfirm')}
+                  onClick={() => openModal('logoutConfirm', { onConfirmLogout: handleLogout })}
                   className='w-full text-left'
                   style={{
                     fontFamily: 'Pretendard',

--- a/src/routes/EntryRoute.tsx
+++ b/src/routes/EntryRoute.tsx
@@ -1,15 +1,17 @@
 import { Navigate, useLocation } from 'react-router-dom';
-import { hasAuthToken } from '@/utils/auth';
+import { useAuthStore } from '@/stores/useAuthStore';
 
 // 첫 진입(/)일 때 어디로 보낼지 결정
 export default function EntryRoute() {
   const { pathname } = useLocation();
 
+  // 스토어에서 로그인 상태 가져오기 (실시간 감지)
+  const isLoggedIn = useAuthStore((state) => state.isLoggedIn);
   // 이미 다른 경로로 들어온 경우엔 건드리지 않음 (안전장치)
   if (pathname !== '/') return null;
 
   // 로그인 상태면 홈
-  if (hasAuthToken()) return <Navigate to='/home/main' replace />;
+  if (isLoggedIn) return <Navigate to='/home/main' replace />;
 
   // 비로그인이면 스플래시
   return <Navigate to='/splash' replace />;

--- a/src/routes/GuestGate.tsx
+++ b/src/routes/GuestGate.tsx
@@ -1,5 +1,5 @@
 import { Navigate, Outlet, useLocation } from 'react-router-dom';
-import { hasAuthToken } from '@/utils/auth';
+import { useAuthStore } from '@/stores/useAuthStore';
 
 /**
  * 비로그인: allow prefixes만 접근 허용 (splash/auth/signup 등)
@@ -14,9 +14,11 @@ const ALLOW_EXACT_PATHS = ['/setting/terms', '/setting/privacy'];
 
 export default function GuestGate() {
   const { pathname } = useLocation();
+  // 스토어에서 로그인 상태 가져오기
+  const isLoggedIn = useAuthStore((state) => state.isLoggedIn);
 
   // 로그인 사용자는 전부 통과
-  if (hasAuthToken()) return <Outlet />;
+  if (isLoggedIn) return <Outlet />;
 
   // 1. exact match 허용
   if (ALLOW_EXACT_PATHS.includes(pathname)) {

--- a/src/stores/useAuthStore.ts
+++ b/src/stores/useAuthStore.ts
@@ -2,7 +2,7 @@ import { create } from 'zustand';
 
 interface AuthState {
   isLoggedIn: boolean; // 전역에서 바라볼 로그인 상태
-  login: (token: string) => void;
+  login: (accessToken: string, refreshToken: string) => void; // 인자 추가
   logout: () => void;
 }
 
@@ -10,13 +10,15 @@ export const useAuthStore = create<AuthState>((set) => ({
   // 초기값: 로컬스토리지에 토큰이 있으면 true
   isLoggedIn: Boolean(localStorage.getItem('accessToken')),
 
-  login: (token) => {
-    localStorage.setItem('accessToken', token);
+  login: (accessToken, refreshToken) => {
+    localStorage.setItem('accessToken', accessToken);
+    localStorage.setItem('refreshToken', refreshToken);
     set({ isLoggedIn: true }); // 전역 알림: 로그인
   },
 
   logout: () => {
     localStorage.removeItem('accessToken');
+    localStorage.removeItem('refreshToken');
     set({ isLoggedIn: false }); // 전역 알림: 로그아웃
   },
 }));

--- a/src/stores/useAuthStore.ts
+++ b/src/stores/useAuthStore.ts
@@ -1,0 +1,22 @@
+import { create } from 'zustand';
+
+interface AuthState {
+  isLoggedIn: boolean; // 전역에서 바라볼 로그인 상태
+  login: (token: string) => void;
+  logout: () => void;
+}
+
+export const useAuthStore = create<AuthState>((set) => ({
+  // 초기값: 로컬스토리지에 토큰이 있으면 true
+  isLoggedIn: Boolean(localStorage.getItem('accessToken')),
+
+  login: (token) => {
+    localStorage.setItem('accessToken', token);
+    set({ isLoggedIn: true }); // 전역 알림: 로그인
+  },
+
+  logout: () => {
+    localStorage.removeItem('accessToken');
+    set({ isLoggedIn: false }); // 전역 알림: 로그아웃
+  },
+}));

--- a/src/types/dto/auth.ts
+++ b/src/types/dto/auth.ts
@@ -123,6 +123,14 @@ export interface LogoutResult {
 }
 export type LogoutResponse = CommonResponse<LogoutResult>;
 
+//회원탈퇴
+export interface WithdrawResult {
+  result: {
+    status: string;
+  };
+}
+export type WithdrawResponse = CommonResponse<WithdrawResult>;
+
 //Profile-setUp 페이지
 //프로필 닉네임 수정
 // 내가 서버로 보낼 데이터 (Request)
@@ -144,5 +152,3 @@ export interface ProfileImageResult {
   profileImageUrl: string;
 }
 export type ProfileImageResponse = CommonResponse<ProfileImageResult>;
-
-//회원탈퇴

--- a/src/types/dto/auth.ts
+++ b/src/types/dto/auth.ts
@@ -118,7 +118,7 @@ export type RefreshTokenResponse = CommonResponse<RefreshTokenResult>;
 // Logout Response
 export interface LogoutResult {
   result: {
-    status: 'Logged Out';
+    status: string;
   };
 }
 export type LogoutResponse = CommonResponse<LogoutResult>;

--- a/src/types/dto/auth.ts
+++ b/src/types/dto/auth.ts
@@ -114,8 +114,14 @@ export interface RefreshTokenResult {
 }
 export type RefreshTokenResponse = CommonResponse<RefreshTokenResult>;
 
+//로그아웃
 // Logout Response
-export type LogoutResponse = CommonResponse<null>;
+export interface LogoutResult {
+  result: {
+    status: 'Logged Out';
+  };
+}
+export type LogoutResponse = CommonResponse<LogoutResult>;
 
 //Profile-setUp 페이지
 //프로필 닉네임 수정
@@ -138,3 +144,5 @@ export interface ProfileImageResult {
   profileImageUrl: string;
 }
 export type ProfileImageResponse = CommonResponse<ProfileImageResult>;
+
+//회원탈퇴

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1,3 +1,0 @@
-export const hasAuthToken = () => {
-  return Boolean(localStorage.getItem('accessToken'));
-};


### PR DESCRIPTION
## 📂 관련 이슈

- closes #124 

--- 로그아웃/회원탈퇴 API 연동

## 🛠️ 작업 사항

- [x] useAuthStore 로직 구현
- [x] Store 사용으로 인한 axios 로직 수정
- [x] hasToken 함수 대신 useAuthStore 사용으로 인한 라우터 분리 로직 수정
- [x] 로그아웃 API 연동
- [x] 회원탈퇴 API 연동

---

## 📸 관련 이미지 (스크린샷 또는 동영상)

---
<img width="252" height="64" alt="image" src="https://github.com/user-attachments/assets/fa2a3363-dca3-4188-8326-bd8a00337796" />
<img width="268" height="78" alt="image" src="https://github.com/user-attachments/assets/a4eea034-51f2-4ff4-9cbd-a9aebf929131" />


## 💬 기타 설명

> 💡 추가적으로 공유할 내용이나 리뷰어에게 전달할 사항이 있다면 작성해 주세요.

-TODO:비밀번호 API PM님 확인 받고 마저 붙이겠습니다.
 -utils에서 auth.ts에서 사용하는 hasToken을 삭제하고 useAuthStore을 생성해 로그인 상태 유지를 하도록 로직을 변경함에 따라 충돌이 발생할 수도 있습니다.
-로그인,소셜로그인,회원가입에 store 사용으로 로직을 전부 수정했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * 서버 연동 로그아웃 및 계정 탈퇴 API 지원 추가
  * 로그아웃/탈퇴를 처리하는 인증 훅 제공(서버 호출 후 로그아웃 및 스플래시로 리다이렉트)

* **개선 사항**
  * 전역 인증 스토어 도입으로 로그인·로그아웃 상태 일원화
  * 토큰 갱신 로직을 스토어 기반으로 재구성해 동시성 및 재시도 안정성 향상
  * 로그인·회원가입·소셜 로그인에서 토큰 저장을 스토어로 위임

* **제거**
  * 기존의 토큰 존재 검사 유틸리티 삭제
<!-- end of auto-generated comment: release notes by coderabbit.ai -->