### PR TITLE
[Feat] 익명 편지 끝내기

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@tanstack/react-query": "^5.90.7",
         "axios": "^1.13.2",
         "clsx": "^2.1.1",
-        "framer-motion": "^12.29.2",
+        "framer-motion": "^12.30.0",
         "iconify": "^1.4.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
@@ -3608,12 +3608,12 @@
       }
     },
     "node_modules/framer-motion": {
-      "version": "12.29.2",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.29.2.tgz",
-      "integrity": "sha512-lSNRzBJk4wuIy0emYQ/nfZ7eWhqud2umPKw2QAQki6uKhZPKm2hRQHeQoHTG9MIvfobb+A/LbEWPJU794ZUKrg==",
+      "version": "12.30.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.30.0.tgz",
+      "integrity": "sha512-S7t3UjvghrFiJzFJ30ncX6keUipexw9f7DRpauhW9bXPNxg0dMxoPbNIDpLuxK1NvxF2wswFEMEm7WiNAcdELg==",
       "license": "MIT",
       "dependencies": {
-        "motion-dom": "^12.29.2",
+        "motion-dom": "^12.30.0",
         "motion-utils": "^12.29.2",
         "tslib": "^2.4.0"
       },
@@ -4481,9 +4481,9 @@
       }
     },
     "node_modules/motion-dom": {
-      "version": "12.29.2",
-      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.29.2.tgz",
-      "integrity": "sha512-/k+NuycVV8pykxyiTCoFzIVLA95Nb1BFIVvfSu9L50/6K6qNeAYtkxXILy/LRutt7AzaYDc2myj0wkCVVYAPPA==",
+      "version": "12.30.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.30.0.tgz",
+      "integrity": "sha512-p6Mp+lxm+mK4O86YVyL6KAlFDVCIqpmcBt+uMVapMBqltPXpwZ5Wj2crnN2VE7lwsas0ONCPIW9YVpMigu4F5g==",
       "license": "MIT",
       "dependencies": {
         "motion-utils": "^12.29.2"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@tanstack/react-query": "^5.90.7",
     "axios": "^1.13.2",
     "clsx": "^2.1.1",
-    "framer-motion": "^12.29.2",
+    "framer-motion": "^12.30.0",
     "iconify": "^1.4.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -65,7 +65,6 @@ import KeywordLetterPage from './pages/report/KeywordLetterPage';
 
 import FriendReplyPage from './pages/friend/FriendReplyPage';
 
-
 import SettingPage from './pages/setting/SettingPage';
 import PasswordResetPage from './pages/setting/PasswordResetPage';
 import AlarmSettingPage from './pages/setting/AlarmSettingPage';

--- a/src/api/stopConversation.ts
+++ b/src/api/stopConversation.ts
@@ -1,0 +1,6 @@
+import { axiosInstance } from '@/api/axios';
+
+export const patchSessionStatus = async (threadId: number) => {
+  const { data } = await axiosInstance.patch(`/matching/sessions/${threadId}/discards`);
+  return data;
+};

--- a/src/api/stopConversation.ts
+++ b/src/api/stopConversation.ts
@@ -1,6 +1,9 @@
 import { axiosInstance } from '@/api/axios';
+import type { PatchSessionStatusResponse } from '@/types/dto/stopConversation';
 
 export const patchSessionStatus = async (threadId: number) => {
-  const { data } = await axiosInstance.patch(`/matching/sessions/${threadId}/discards`);
+  const { data } = await axiosInstance.patch<PatchSessionStatusResponse>(
+    `/matching/sessions/${threadId}/discards`,
+  );
   return data;
 };

--- a/src/hooks/useDiscardSession.ts
+++ b/src/hooks/useDiscardSession.ts
@@ -1,0 +1,10 @@
+import { useMutation } from '@tanstack/react-query';
+import { patchSessionStatus } from '@/api/stopConversation';
+
+type Vars = { threadId: number };
+
+export function useDiscardSession() {
+  return useMutation({
+    mutationFn: ({ threadId }: Vars) => patchSessionStatus(threadId),
+  });
+}

--- a/src/modals/LetterSendingConfirmModal.tsx
+++ b/src/modals/LetterSendingConfirmModal.tsx
@@ -23,8 +23,8 @@ export default function LetterSendingConfirmModal() {
 
   const getTargetText = () => {
     // TODO : 추후 라이팅 주소 확인 필요
-    if (pathname.includes('/letter/other/decorate') || pathname.includes('/letter/anon/decorate'))
-      return `${senderName}님에게 편지를`;
+    if (pathname.includes('/letter/anon/decorate')) return `익명 친구에게 편지를`;
+    if (pathname.includes('/letter/other/decorate')) return `${senderName}님에게 편지를`;
     if (pathname.includes('/letter/self/decorate')) return '미래의 나에게 편지를';
     if (pathname.includes('/letter/friend/decorate')) return `${friendName}님에게 편지를`;
     return '편지를';

--- a/src/pages/friend/FriendRequestPage.tsx
+++ b/src/pages/friend/FriendRequestPage.tsx
@@ -23,23 +23,12 @@ export default function FriendRequestPage() {
 
   const setActiveTarget = useLetterStore((s) => s.setActiveTarget);
   const patchDraft = useLetterStore((s) => s.patchDraft);
-  // const { data: incoming = [] } = useIncomingFriendRequests();
+  const { data: incoming = [] } = useIncomingFriendRequests();
   // TODO : 이전 friend draft를 리셋해야 하는가?
   // 이전 friend draft 임시저장 -> 다른 친구에게 새로 작성하려고 하면 모달 띄우기
   // (임시 저장된 글이 있습니다. 삭제하고 새로 작성하시겠어요?)
   // const resetCurrent = useLetterStore((s) => s.resetCurrent);
-  // const { data: outgoing = [] } = useOutgoingFriendRequests();
-
-  // 🔧 더미 데이터
-  const incomingDummy = [{ requesterUserId: 1 }];
-  const outgoingDummy = [{ receiverUserId: 3 }];
-
-  // 🔁 실제 데이터 없으면 더미 사용
-  const { data: incomingData } = useIncomingFriendRequests();
-  const { data: outgoingData } = useOutgoingFriendRequests();
-
-  const incoming = incomingData?.length ? incomingData : incomingDummy;
-  const outgoing = outgoingData?.length ? outgoingData : outgoingDummy;
+  const { data: outgoing = [] } = useOutgoingFriendRequests();
 
   const acceptMutation = useAcceptFriendRequest();
   const rejectMutation = useRejectFriendRequest();

--- a/src/pages/friend/FriendRequestPage.tsx
+++ b/src/pages/friend/FriendRequestPage.tsx
@@ -31,8 +31,8 @@ export default function FriendRequestPage() {
   // const { data: outgoing = [] } = useOutgoingFriendRequests();
 
   // 🔧 더미 데이터
-  const incomingDummy = [{ requesterUserId: 101 }];
-  const outgoingDummy = [{ receiverUserId: 202 }];
+  const incomingDummy = [{ requesterUserId: 1 }];
+  const outgoingDummy = [{ receiverUserId: 3 }];
 
   // 🔁 실제 데이터 없으면 더미 사용
   const { data: incomingData } = useIncomingFriendRequests();

--- a/src/pages/friend/FriendRequestPage.tsx
+++ b/src/pages/friend/FriendRequestPage.tsx
@@ -23,12 +23,23 @@ export default function FriendRequestPage() {
 
   const setActiveTarget = useLetterStore((s) => s.setActiveTarget);
   const patchDraft = useLetterStore((s) => s.patchDraft);
-  const { data: incoming = [] } = useIncomingFriendRequests();
+  // const { data: incoming = [] } = useIncomingFriendRequests();
   // TODO : 이전 friend draft를 리셋해야 하는가?
   // 이전 friend draft 임시저장 -> 다른 친구에게 새로 작성하려고 하면 모달 띄우기
   // (임시 저장된 글이 있습니다. 삭제하고 새로 작성하시겠어요?)
   // const resetCurrent = useLetterStore((s) => s.resetCurrent);
-  const { data: outgoing = [] } = useOutgoingFriendRequests();
+  // const { data: outgoing = [] } = useOutgoingFriendRequests();
+
+  // 🔧 더미 데이터
+  const incomingDummy = [{ requesterUserId: 101 }];
+  const outgoingDummy = [{ receiverUserId: 202 }];
+
+  // 🔁 실제 데이터 없으면 더미 사용
+  const { data: incomingData } = useIncomingFriendRequests();
+  const { data: outgoingData } = useOutgoingFriendRequests();
+
+  const incoming = incomingData?.length ? incomingData : incomingDummy;
+  const outgoing = outgoingData?.length ? outgoingData : outgoingDummy;
 
   const acceptMutation = useAcceptFriendRequest();
   const rejectMutation = useRejectFriendRequest();

--- a/src/pages/letter/LetterReplyPage.tsx
+++ b/src/pages/letter/LetterReplyPage.tsx
@@ -108,9 +108,10 @@ export default function LetterReplyPage() {
         // 그냥 닫히고 계속 작성
       },
       onStopConversation: () => {
+        // 이 부분에 patch 요청
         // other-stop 페이지로 이동
         navigate('/letter/other-stop', {
-          state: { friendName: senderName, totalCount: 7 },
+          state: { totalCount: 7 },
         });
       },
     });

--- a/src/pages/letter/LetterReplyPage.tsx
+++ b/src/pages/letter/LetterReplyPage.tsx
@@ -11,6 +11,8 @@ import { DEFAULT_FONT_ID, FONT_ASSET_MAP } from '@/constants/fontAssets';
 import { DEFAULT_PAPER_ID, PAPER_ASSET_MAP } from '@/constants/paperAssets';
 import { useModalStore } from '@/stores/modalStore';
 import { useThreadFlowStore } from '@/stores/letterContextStore';
+import { useDiscardSession } from '@/hooks/useDiscardSession';
+import { useGlobalToast } from '@/components/toast/ToastProvider';
 
 type ReplyData = {
   title: string;
@@ -49,14 +51,16 @@ const parseSentAt = (isoOrNull: string | null) => {
 
 export default function LetterReplyPage() {
   const navigate = useNavigate();
+  const { openModal } = useModalStore();
+  const { showToast } = useGlobalToast();
+
   const { letterId: letterIdParam } = useParams();
   const letterId = letterIdParam ? Number(letterIdParam) : 0;
-
   const senderName = useThreadFlowStore((s) => s.senderName) ?? '익명';
 
   const { data, isLoading, isError, refetch } = useLetterDetail(letterId);
-
-  const { openModal } = useModalStore();
+  const discardSession = useDiscardSession();
+  const threadId = useThreadFlowStore((t) => t.threadId);
 
   const view = useMemo<ReplyData | null>(() => {
     if (!data) return null;
@@ -108,11 +112,23 @@ export default function LetterReplyPage() {
         // 그냥 닫히고 계속 작성
       },
       onStopConversation: () => {
-        // 이 부분에 patch 요청
-        // other-stop 페이지로 이동
-        navigate('/letter/other-stop', {
-          state: { totalCount: 7 },
-        });
+        // patch 요청
+        if (!threadId) return;
+
+        discardSession.mutate(
+          { threadId },
+          {
+            onSuccess: () => {
+              // other-stop 페이지로 이동
+              navigate('/letter/other-stop', {
+                state: { totalCount: 7 },
+              });
+            },
+            onError: () => {
+              showToast('요청에 실패했습니다. 잠시 후 다시 요청해주세요.', 'error');
+            },
+          },
+        );
       },
     });
   };

--- a/src/pages/letter/LetterReplyPage.tsx
+++ b/src/pages/letter/LetterReplyPage.tsx
@@ -112,20 +112,28 @@ export default function LetterReplyPage() {
         // 그냥 닫히고 계속 작성
       },
       onStopConversation: () => {
-        // patch 요청
-        if (!threadId) return;
+        if (!threadId) {
+          navigate('error/404', { replace: true });
+          return;
+        }
 
+        // patch 요청
         discardSession.mutate(
           { threadId },
           {
-            onSuccess: () => {
-              // other-stop 페이지로 이동
-              navigate('/letter/other-stop', {
-                state: { totalCount: 7 },
-              });
+            onSuccess: (res) => {
+              if (res.resultType !== 'SUCCESS' || !res.success) {
+                showToast('요청에 실패했습니다. 잠시 후 다시 시도해주세요.', 'error');
+                return;
+              }
+
+              // patch 성공시 응답으로 주고받은 횟수를 받음(maxTurns) > totalCount로 넘김
+              const totalCount = res.success.result.data.maxTurns;
+              navigate('/letter/other-stop', { state: { totalCount } });
             },
-            onError: () => {
-              showToast('요청에 실패했습니다. 잠시 후 다시 요청해주세요.', 'error');
+            onError: (err) => {
+              console.error(err);
+              showToast('요청을 실패했어요. 잠시 후 다시 시도해주세요.', 'error');
             },
           },
         );

--- a/src/pages/letter/LetterReplyPage.tsx
+++ b/src/pages/letter/LetterReplyPage.tsx
@@ -113,7 +113,7 @@ export default function LetterReplyPage() {
       },
       onStopConversation: () => {
         if (!threadId) {
-          navigate('error/404', { replace: true });
+          navigate('/error/404', { replace: true });
           return;
         }
 

--- a/src/pages/letter/LetterSendingPage.tsx
+++ b/src/pages/letter/LetterSendingPage.tsx
@@ -112,12 +112,17 @@ const LetterSendingPage = () => {
 
         console.log('[CreateLetter success response]', res);
 
-        // ✅ 테스트: 성공하면 무조건 transition
-        navigate(`/friend/sent-transition/${threadId}`, { replace: true });
-        // navigate('/home/main', {
-        //   replace: true,
-        //   state: { toast: { status: 'success', message: '편지를 전송했어요!' } },
-        // });
+        // TODO : 실제 응답/스토어 값으로 교체
+        const letterCount = 0; // 임시
+
+        if (letterCount === 10) {
+          navigate(`/friend/sent-transition/${threadId}`, { replace: true });
+        } else {
+          navigate('/home/main', {
+            replace: true,
+            state: { toast: { status: 'success', message: '편지를 전송했어요!' } },
+          });
+        }
       } catch {
         hasSentRef.current = false;
         showToast('편지 전송에 실패했어요.', 'error');

--- a/src/types/dto/stopConversation.ts
+++ b/src/types/dto/stopConversation.ts
@@ -1,11 +1,9 @@
 import type { CommonResponse } from './common';
 
-export type SessionStatus = 'FRIENDS' | 'DISCARDED';
-
 export type SessionData = {
   id: number;
   questionId: number;
-  status: SessionStatus;
+  status: string;
   maxTurns: number;
   startedAt: string; // ISO
   endedAt: string | null; // ISO or null
@@ -18,4 +16,4 @@ export type PatchSessionStatusSuccess = {
   };
 };
 
-export type PatchSessionStatusResponse = CommonResponse<S>;
+export type PatchSessionStatusResponse = CommonResponse<PatchSessionStatusSuccess>;

--- a/src/types/dto/stopConversation.ts
+++ b/src/types/dto/stopConversation.ts
@@ -1,0 +1,21 @@
+import type { CommonResponse } from './common';
+
+export type SessionStatus = 'FRIENDS' | 'DISCARDED';
+
+export type SessionData = {
+  id: number;
+  questionId: number;
+  status: SessionStatus;
+  maxTurns: number;
+  startedAt: string; // ISO
+  endedAt: string | null; // ISO or null
+};
+
+export type PatchSessionStatusSuccess = {
+  message: string;
+  result: {
+    data: SessionData;
+  };
+};
+
+export type PatchSessionStatusResponse = CommonResponse<S>;


### PR DESCRIPTION
## 📂 관련 이슈

- closes #119 

---

## 🛠️ 작업 사항

- [x] PATCH DTO, API 호출 함수, mutation 훅 생성
- [x] LetterReplyPage에 연동
- [x] 테스트 

---

## 📸 관련 이미지 (스크린샷 또는 동영상)
<img width="1919" height="1086" alt="스크린샷 2026-02-04 022800" src="https://github.com/user-attachments/assets/c28310ac-f62d-4979-8fed-e38bc16a2f8b" />

---

## 💬 기타 설명

> 💡 백엔드와 threadId 이슈로 소통 필요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 대화 중단(세션 중단) 흐름 추가 — 중단 요청 후 응답에 따라 종료 화면으로 이동하고 오류 시 안내합니다.
  * 편지 발송 후 조건부 페이지 이동 도입 — 발송 결과에 따른 분기 처리로 이동 경로가 달라집니다.
  * 편지 모달의 대상 텍스트 표시 개선 — 경로별로 수신자 문구가 더 정확하게 노출됩니다.

* **Chores**
  * framer-motion 의존성 업데이트 (12.29.2 → 12.30.0)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->