### PR TITLE
[Feat]  마이페이지 API 연동 및 프로필 수정 API 로직 수정 

### DIFF
--- a/src/api/profile.ts
+++ b/src/api/profile.ts
@@ -1,0 +1,11 @@
+import type { MyProfileResponse } from '@/types/dto/profile';
+import { axiosInstance } from './axios';
+
+/**
+ * 사용자의 프로필 정보를 조회
+ * GET /users/me/profile
+ */
+export const onboardingApi = async (): Promise<MyProfileResponse> => {
+  const { data } = await axiosInstance.get<MyProfileResponse>('/users/me/profile');
+  return data;
+};

--- a/src/api/profile.ts
+++ b/src/api/profile.ts
@@ -5,7 +5,7 @@ import { axiosInstance } from './axios';
  * 사용자의 프로필 정보를 조회
  * GET /users/me/profile
  */
-export const onboardingApi = async (): Promise<MyProfileResponse> => {
+export const getMyProfile = async (): Promise<MyProfileResponse> => {
   const { data } = await axiosInstance.get<MyProfileResponse>('/users/me/profile');
   return data;
 };

--- a/src/components/common/QuestionCard.tsx
+++ b/src/components/common/QuestionCard.tsx
@@ -1,3 +1,6 @@
+import { ROUTES } from '@/routes/paths';
+import { useNavigate } from 'react-router-dom';
+
 interface QuestionCardProps {
   question: string;
   timeLeft: string;
@@ -5,6 +8,10 @@ interface QuestionCardProps {
 }
 
 export default function QuestionCard({ question, timeLeft, profileImageUrl }: QuestionCardProps) {
+  const navigate = useNavigate();
+  const handleMypage = () => {
+    navigate(ROUTES.my.mypage);
+  };
   return (
     <div
       className='w-full px-4 py-2.5'
@@ -43,6 +50,7 @@ export default function QuestionCard({ question, timeLeft, profileImageUrl }: Qu
         {/* 프로필 이미지 */}
         {profileImageUrl && (
           <div
+            onClick={handleMypage}
             className='flex-shrink-0 rounded-full overflow-hidden'
             style={{
               width: '47px',

--- a/src/components/common/QuestionCard.tsx
+++ b/src/components/common/QuestionCard.tsx
@@ -51,7 +51,7 @@ export default function QuestionCard({ question, timeLeft, profileImageUrl }: Qu
         {profileImageUrl && (
           <div
             onClick={handleMypage}
-            className='flex-shrink-0 rounded-full overflow-hidden'
+            className='flex-shrink-0 rounded-full overflow-hidden cursor-pointer'
             style={{
               width: '47px',
               height: '48px',

--- a/src/hooks/useMyProfile.ts
+++ b/src/hooks/useMyProfile.ts
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query';
+import { getMyProfile } from '@/api/profile';
+
+export const useMyProfile = () => {
+  return useQuery({
+    queryKey: ['myProfile'],
+    queryFn: getMyProfile,
+    select: (response) => response.success,
+    staleTime: 1000 * 60 * 5, // 5분 동안은 신선한 데이터로 간주
+  });
+};

--- a/src/pages/login/ProfileSetUpPage.tsx
+++ b/src/pages/login/ProfileSetUpPage.tsx
@@ -11,9 +11,8 @@ import { useGlobalToast } from '@/components/toast/ToastProvider';
 import { useMyProfile } from '@/hooks/useMyProfile';
 import { useQueryClient } from '@tanstack/react-query';
 
-const { data: existingProfile } = useMyProfile();
-
 const ProfileSetUpPage = () => {
+  const { data: existingProfile } = useMyProfile();
   const navigate = useNavigate();
   const { showToast } = useGlobalToast();
   const queryClient = useQueryClient();
@@ -25,6 +24,8 @@ const ProfileSetUpPage = () => {
   //프로필 사진 업로드 상태 관리
   const [profileImage, setProfileImage] = useState<File | null>(null); // 업로드할 파일 객체
   const [previewUrl, setPreviewUrl] = useState<string>(''); // 화면에 보여줄 미리보기 URL
+
+  const isEditMode = !!(existingProfile?.nickname || existingProfile?.profileImageUrl);
 
   // 파일 인풋 제어를 위한 ref
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -73,8 +74,13 @@ const ProfileSetUpPage = () => {
         await postProfileImage(profileImage);
       }
       await queryClient.invalidateQueries({ queryKey: ['myProfile'] });
-      // 전체 성공 시 이동
-      navigate(ROUTES.onboarding.start);
+
+      // ✅ 조건에 따른 페이지 이동
+      if (isEditMode) {
+        navigate(ROUTES.my.mypage); // 기존 유저는 마이페이지로
+      } else {
+        navigate(ROUTES.onboarding.start); // 신규 유저는 온보딩으로
+      }
     } catch (error: unknown) {
       // 상세한 에러 피드백
       showToast('설정 중 에러가 발생했습니다.', 'error');
@@ -110,8 +116,8 @@ const ProfileSetUpPage = () => {
   }, [previewUrl]);
   useEffect(() => {
     if (existingProfile) {
-      setNickname(existingProfile.nickname);
-      setPreviewUrl(existingProfile.profileImageUrl);
+      setNickname(existingProfile.nickname || '');
+      setPreviewUrl(existingProfile.profileImageUrl || '');
       // 이미지는 파일 객체가 아니므로 profileImage는 null 유지 (수정할 때만 담김)
     }
   }, [existingProfile]);
@@ -125,7 +131,11 @@ const ProfileSetUpPage = () => {
         <div className='relative'>
           <div className='w-[128px] h-[128px] bg-[var(--color-primary-100)] rounded-full mb-3 overflow-hidden'>
             {previewUrl ? (
-              <img src={previewUrl} alt='프로필 미리보기' className='w-full h-full object-cover' />
+              <img
+                src={previewUrl.startsWith('blob:') ? previewUrl : `${previewUrl}?t=${Date.now()}`}
+                alt='프로필 미리보기'
+                className='w-full h-full object-cover'
+              />
             ) : (
               <div className='w-full h-full bg-[var(--color-primary-100)]' />
             )}
@@ -204,7 +214,7 @@ const ProfileSetUpPage = () => {
 
       <div className='fixed bottom-[40px] left-0 right-0 mx-auto w-full max-w-[375px] px-4'>
         <Button onClick={handleOnboarding} disabled={!isValid || isLoading}>
-          {existingProfile?.nickname ? '완료' : '시작하기'}
+          {isEditMode ? '완료' : '시작하기'}
         </Button>
       </div>
     </div>

--- a/src/pages/login/ProfileSetUpPage.tsx
+++ b/src/pages/login/ProfileSetUpPage.tsx
@@ -8,10 +8,15 @@ import { useNavigate } from 'react-router-dom';
 import { ROUTES } from '@/routes/paths';
 import { patchNickname, postProfileImage } from '@/api/auth';
 import { useGlobalToast } from '@/components/toast/ToastProvider';
+import { useMyProfile } from '@/hooks/useMyProfile';
+import { useQueryClient } from '@tanstack/react-query';
+
+const { data: existingProfile } = useMyProfile();
 
 const ProfileSetUpPage = () => {
   const navigate = useNavigate();
   const { showToast } = useGlobalToast();
+  const queryClient = useQueryClient();
   //  닉네임 입력 상태 관리
   const [nickname, setNickname] = useState('');
 
@@ -67,7 +72,7 @@ const ProfileSetUpPage = () => {
       if (profileImage) {
         await postProfileImage(profileImage);
       }
-
+      await queryClient.invalidateQueries({ queryKey: ['myProfile'] });
       // 전체 성공 시 이동
       navigate(ROUTES.onboarding.start);
     } catch (error: unknown) {
@@ -103,7 +108,13 @@ const ProfileSetUpPage = () => {
       }
     };
   }, [previewUrl]);
-
+  useEffect(() => {
+    if (existingProfile) {
+      setNickname(existingProfile.nickname);
+      setPreviewUrl(existingProfile.profileImageUrl);
+      // 이미지는 파일 객체가 아니므로 profileImage는 null 유지 (수정할 때만 담김)
+    }
+  }, [existingProfile]);
   return (
     <div className='w-[375px] h-screen bg-[#FAFAFA]! mx-auto flex flex-col '>
       <div className='[&>*]:!bg-[#FAFAFA]'>
@@ -193,7 +204,7 @@ const ProfileSetUpPage = () => {
 
       <div className='fixed bottom-[40px] left-0 right-0 mx-auto w-full max-w-[375px] px-4'>
         <Button onClick={handleOnboarding} disabled={!isValid || isLoading}>
-          시작하기
+          {existingProfile?.nickname ? '완료' : '시작하기'}
         </Button>
       </div>
     </div>

--- a/src/pages/login/ProfileSetUpPage.tsx
+++ b/src/pages/login/ProfileSetUpPage.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@/components/common/Button';
 import BackHeader from '@/components/common/headers/BackHeader';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import Question from '@/assets/icons/Question.svg?react';
 import { FaCamera } from 'react-icons/fa';
 import { validate } from '@/utils/validate';
@@ -24,7 +24,9 @@ const ProfileSetUpPage = () => {
   //프로필 사진 업로드 상태 관리
   const [profileImage, setProfileImage] = useState<File | null>(null); // 업로드할 파일 객체
   const [previewUrl, setPreviewUrl] = useState<string>(''); // 화면에 보여줄 미리보기 URL
+  const cacheBuster = useMemo(() => Date.now(), []);
 
+  //프로필 수정인지 프로필입력인지 확인
   const isEditMode = !!(existingProfile?.nickname || existingProfile?.profileImageUrl);
 
   // 파일 인풋 제어를 위한 ref
@@ -132,7 +134,7 @@ const ProfileSetUpPage = () => {
           <div className='w-[128px] h-[128px] bg-[var(--color-primary-100)] rounded-full mb-3 overflow-hidden'>
             {previewUrl ? (
               <img
-                src={previewUrl.startsWith('blob:') ? previewUrl : `${previewUrl}?t=${Date.now()}`}
+                src={previewUrl.startsWith('blob:') ? previewUrl : `${previewUrl}?t=${cacheBuster}`}
                 alt='프로필 미리보기'
                 className='w-full h-full object-cover'
               />

--- a/src/pages/login/ProfileSetUpPage.tsx
+++ b/src/pages/login/ProfileSetUpPage.tsx
@@ -27,7 +27,9 @@ const ProfileSetUpPage = () => {
   const cacheBuster = useMemo(() => Date.now(), []);
 
   //프로필 수정인지 프로필입력인지 확인
-  const isEditMode = !!(existingProfile?.nickname || existingProfile?.profileImageUrl);
+  const isEditMode = !!(
+    existingProfile?.nickname?.trim() || existingProfile?.profileImageUrl?.trim()
+  );
 
   // 파일 인풋 제어를 위한 ref
   const fileInputRef = useRef<HTMLInputElement>(null);

--- a/src/pages/login/ProfileSetUpPage.tsx
+++ b/src/pages/login/ProfileSetUpPage.tsx
@@ -12,7 +12,7 @@ import { useMyProfile } from '@/hooks/useMyProfile';
 import { useQueryClient } from '@tanstack/react-query';
 
 const ProfileSetUpPage = () => {
-  const { data: existingProfile } = useMyProfile();
+  const { data: existingProfile, isPending: isProfileLoading } = useMyProfile();
   const navigate = useNavigate();
   const { showToast } = useGlobalToast();
   const queryClient = useQueryClient();
@@ -217,7 +217,7 @@ const ProfileSetUpPage = () => {
       </div>
 
       <div className='fixed bottom-[40px] left-0 right-0 mx-auto w-full max-w-[375px] px-4'>
-        <Button onClick={handleOnboarding} disabled={!isValid || isLoading}>
+        <Button onClick={handleOnboarding} disabled={!isValid || isLoading || isProfileLoading}>
           {isEditMode ? '완료' : '시작하기'}
         </Button>
       </div>

--- a/src/pages/main/Mainpage.tsx
+++ b/src/pages/main/Mainpage.tsx
@@ -89,7 +89,11 @@ const MainPage = () => {
         <QuestionCard
           question={formattedQuestionText}
           timeLeft={timeLeft}
-          profileImageUrl={homeSummary?.user?.profileImageUrl || 'https://placehold.co/47x48'}
+          profileImageUrl={
+            homeSummary?.user?.profileImageUrl
+              ? `${homeSummary.user.profileImageUrl}?t=${Date.now()}`
+              : 'https://placehold.co/47x48'
+          }
         />
       </section>
 

--- a/src/pages/main/Mainpage.tsx
+++ b/src/pages/main/Mainpage.tsx
@@ -55,6 +55,7 @@ const MainPage = () => {
       })) ?? [],
     [friendPublicLetters],
   );
+  const profileImageCacheBuster = useMemo(() => Date.now(), [homeSummary?.user?.profileImageUrl]);
 
   // 편지 발송 후 성공 토스트 뜨면 resetAll 실행
   useEffect(() => {
@@ -91,7 +92,7 @@ const MainPage = () => {
           timeLeft={timeLeft}
           profileImageUrl={
             homeSummary?.user?.profileImageUrl
-              ? `${homeSummary.user.profileImageUrl}?t=${Date.now()}`
+              ? `${homeSummary.user.profileImageUrl}?t=${profileImageCacheBuster}`
               : 'https://placehold.co/47x48'
           }
         />

--- a/src/pages/my/MyPage.tsx
+++ b/src/pages/my/MyPage.tsx
@@ -43,7 +43,11 @@ const MyPage = () => {
           <div className='w-[90px] h-[90px] rounded-full bg-[var(--color-primary-100)] flex-shrink-0 overflow-hidden border border-[var(--color-line-normal)]'>
             {response.profileImageUrl ? (
               <img
-                src={response.profileImageUrl}
+                src={
+                  response.profileImageUrl
+                    ? `${response.profileImageUrl}?t=${Date.now()}`
+                    : '/default-profile.png'
+                }
                 alt='프로필'
                 className='w-full h-full object-cover'
               />

--- a/src/pages/my/MyPage.tsx
+++ b/src/pages/my/MyPage.tsx
@@ -7,9 +7,13 @@ import { useNavigate } from 'react-router-dom';
 
 import { useActivityStore } from '@/stores/activityStore';
 import { useMyProfile } from '@/hooks/useMyProfile';
+import { ROUTES } from '@/routes/paths';
 
 const MyPage = () => {
   const navigate = useNavigate();
+  const handleProfilEedit = () => {
+    return navigate(ROUTES.auth.profile);
+  };
 
   // 관심사 조회 (enabled는 true로 두면 됨)
   const { data: response, isLoading, isError } = useMyProfile();
@@ -48,8 +52,7 @@ const MyPage = () => {
           <button
             type='button'
             className='flex-shrink-0 px-3 py-2 border border-[var(--color-line-normal)] rounded-xl ty-body5 text-[var(--color-text-normal)]'
-            // TODO: 프로필 편집 기능 미구현. 추후 /onboarding/profile-select?mode=edit 등으로 연결 필요
-            disabled
+            onClick={handleProfilEedit}
           >
             프로필 수정
           </button>

--- a/src/pages/my/MyPage.tsx
+++ b/src/pages/my/MyPage.tsx
@@ -10,6 +10,8 @@ import { useMyProfile } from '@/hooks/useMyProfile';
 import { ROUTES } from '@/routes/paths';
 import { getInterestEmoji } from '@/constants/interestUiMap';
 import { useMemo } from 'react';
+import ErrorPage from '../system/ErrorPage';
+import LoadingPage from '../system/LoadingPage';
 
 const MyPage = () => {
   const navigate = useNavigate();
@@ -27,9 +29,8 @@ const MyPage = () => {
   const totalUsageMinutes = Math.floor(totalSeconds / 60);
 
   // 2. 로딩 및 에러 처리 (필수)
-  if (isLoading) return <div className='w-[375px] mx-auto py-20 text-center'>로딩 중...</div>;
-  if (isError || !response)
-    return <div className='w-[375px] mx-auto py-20 text-center'>데이터를 가져오지 못했습니다.</div>;
+  if (isLoading) return <LoadingPage />;
+  if (isError || !response) return <ErrorPage />;
   // 온도값을 0~100으로 clamp(기본이 36.5)
   const currentTemp = response?.temperatureAvg ?? 36.5;
   const safeTemp = Math.max(0, Math.min(100, currentTemp));

--- a/src/pages/my/MyPage.tsx
+++ b/src/pages/my/MyPage.tsx
@@ -4,36 +4,25 @@ import { HiPaperAirplane } from 'react-icons/hi2';
 import { HiEnvelope } from 'react-icons/hi2';
 import { HiClock } from 'react-icons/hi2';
 import { useNavigate } from 'react-router-dom';
-import { useMyInterests } from '@/hooks/onboarding/useMyInterests';
-import { useMemo } from 'react';
+
 import { useActivityStore } from '@/stores/activityStore';
+import { useMyProfile } from '@/hooks/useMyProfile';
 
 const MyPage = () => {
   const navigate = useNavigate();
 
   // 관심사 조회 (enabled는 true로 두면 됨)
-  const {
-    data: interestsItems, // ← useMyInterests가 items만 반환(select)하는 훅이라면 배열이 바로 옴
-  } = useMyInterests(true);
+  const { data: response, isLoading, isError } = useMyProfile();
 
   const totalSeconds = useActivityStore((s) => s.totalSeconds);
   const totalUsageMinutes = Math.floor(totalSeconds / 60);
 
-  // Mock data - 실제 사용 시 API에서 가져오기
-  const userInfo = {
-    nickname: '개굴님',
-    email: 'gaegull_01@naver.com',
-    temperature: 66,
-    sentLetters: 8,
-    receivedLetters: 12,
-  };
-
+  // 2. 로딩 및 에러 처리 (필수)
+  if (isLoading) return <div className='w-[375px] mx-auto py-20 text-center'>로딩 중...</div>;
+  if (isError || !response)
+    return <div className='w-[375px] mx-auto py-20 text-center'>데이터를 가져오지 못했습니다.</div>;
   // 온도값을 0~100으로 clamp
-  const safeTemp = Math.max(0, Math.min(100, userInfo.temperature));
-
-  const interests = useMemo(() => {
-    return interestsItems ?? [];
-  }, [interestsItems]);
+  const safeTemp = Math.max(0, Math.min(100, response.temperatureAvg));
 
   return (
     <div className='w-[375px] min-h-screen mx-auto bg-[var(--color-bg-500)]'>
@@ -51,8 +40,8 @@ const MyPage = () => {
 
           {/* User Info */}
           <div className='flex-1 min-w-0 pb-1'>
-            <p className='ty-body4 text-[var(--color-text-normal)]'>{userInfo.nickname}</p>
-            <p className='ty-body5 text-[var(--color-text-assistive)] truncate'>{userInfo.email}</p>
+            <p className='ty-body4 text-[var(--color-text-normal)]'>{response.nickname}</p>
+            <p className='ty-body5 text-[var(--color-text-assistive)] truncate'>{response.email}</p>
           </div>
 
           {/* Edit Button */}
@@ -81,7 +70,7 @@ const MyPage = () => {
           </div>
 
           <div className='flex gap-2 flex-wrap justify-center'>
-            {interests.map((item) => (
+            {response.interests.map((item) => (
               <span
                 key={item.id}
                 className='px-5 py-2 rounded-full border border-[var(--color-line-normal)] ty-body3 text-[var(--color-text-normal)]'
@@ -132,7 +121,7 @@ const MyPage = () => {
                 <span className='ty-body5 text-[var(--color-text-normal)]'>내가 보낸 편지</span>
               </div>
               <span className='ty-body4 text-[var(--color-text-normal)]'>
-                {userInfo.sentLetters}통
+                {response.sentLettersCount}통
               </span>
             </div>
 
@@ -142,7 +131,7 @@ const MyPage = () => {
                 <span className='ty-body5 text-[var(--color-text-normal)]'>내가 받은 편지</span>
               </div>
               <span className='ty-body4 text-[var(--color-text-normal)]'>
-                {userInfo.receivedLetters}통
+                {response.receivedLettersCount}통
               </span>
             </div>
 

--- a/src/pages/my/MyPage.tsx
+++ b/src/pages/my/MyPage.tsx
@@ -9,12 +9,16 @@ import { useActivityStore } from '@/stores/activityStore';
 import { useMyProfile } from '@/hooks/useMyProfile';
 import { ROUTES } from '@/routes/paths';
 import { getInterestEmoji } from '@/constants/interestUiMap';
+import { useMemo } from 'react';
 
 const MyPage = () => {
   const navigate = useNavigate();
   const handleProfilEedit = () => {
     return navigate(ROUTES.auth.profile);
   };
+
+  // 컴포넌트가 처음 생성될 때 한 번만 현재 시간을 저장 (캐시 버스터 고정)
+  const cacheBuster = useMemo(() => Date.now(), []);
 
   // 관심사 조회 (enabled는 true로 두면 됨)
   const { data: response, isLoading, isError } = useMyProfile();
@@ -44,20 +48,13 @@ const MyPage = () => {
           <div className='w-[90px] h-[90px] rounded-full bg-[var(--color-primary-100)] flex-shrink-0 overflow-hidden border border-[var(--color-line-normal)]'>
             {response.profileImageUrl ? (
               <img
-                src={
-                  response.profileImageUrl
-                    ? `${response.profileImageUrl}?t=${Date.now()}`
-                    : '/default-profile.png'
-                }
+                src={`${response.profileImageUrl}?t=${cacheBuster}`}
                 alt='프로필'
                 className='w-full h-full object-cover'
               />
             ) : (
-              /* 이미지가 없을 때 보여줄 기본 아이콘이나 빈 화면 */
-              <div className='w-full h-full flex items-center justify-center text-[var(--color-primary-300)]'>
-                {/* 아이콘 예시 (선택사항) */}
-                <span className='text-xs'>No Image</span>
-              </div>
+              /* 이미지가 없을 때 보여줄 빈 화면 */
+              <div className='w-full h-full flex items-center justify-center text-[var(--color-primary-300)]'></div>
             )}
           </div>
 

--- a/src/pages/my/MyPage.tsx
+++ b/src/pages/my/MyPage.tsx
@@ -26,7 +26,7 @@ const MyPage = () => {
   if (isError || !response)
     return <div className='w-[375px] mx-auto py-20 text-center'>데이터를 가져오지 못했습니다.</div>;
   // 온도값을 0~100으로 clamp
-  const safeTemp = Math.max(0, Math.min(100, response.temperatureAvg));
+  const safeTemp = Math.max(0, Math.min(100, 0));
 
   return (
     <div className='w-[375px] min-h-screen mx-auto bg-[var(--color-bg-500)]'>
@@ -40,7 +40,21 @@ const MyPage = () => {
         {/* Profile Section */}
         <section className='pb-4 flex items-end gap-2'>
           {/* Avatar */}
-          <div className='w-[90px] h-[90px] rounded-full bg-[var(--color-primary-100)] flex-shrink-0' />
+          <div className='w-[90px] h-[90px] rounded-full bg-[var(--color-primary-100)] flex-shrink-0 overflow-hidden border border-[var(--color-line-normal)]'>
+            {response.profileImageUrl ? (
+              <img
+                src={response.profileImageUrl}
+                alt='프로필'
+                className='w-full h-full object-cover'
+              />
+            ) : (
+              /* 이미지가 없을 때 보여줄 기본 아이콘이나 빈 화면 */
+              <div className='w-full h-full flex items-center justify-center text-[var(--color-primary-300)]'>
+                {/* 아이콘 예시 (선택사항) */}
+                <span className='text-xs'>No Image</span>
+              </div>
+            )}
+          </div>
 
           {/* User Info */}
           <div className='flex-1 min-w-0 pb-1'>
@@ -89,25 +103,27 @@ const MyPage = () => {
           <h2 className='ty-body2 text-[var(--color-text-normal)] mb-8'>현재 나의 온도</h2>
 
           {/* Temperature Gauge */}
-          <div className='mb-8'>
-            <div className='relative h-2 bg-[var(--color-primary-100)] rounded-full'>
-              {/* Filled portion */}
-              <div
-                className='absolute left-0 top-0 h-full bg-[var(--color-primary-400)] rounded-full'
-                style={{ width: `${safeTemp}%` }}
-              />
-              {/* Indicator circle */}
-              <div
-                className='absolute top-1/2 -translate-y-1/2 w-5 h-5 bg-[var(--color-primary-400)] rounded-full border-2 border-white shadow-[0_0_10px_rgba(0,0,0,0.1)]'
-                style={{ left: `calc(${safeTemp}% - 10px)` }}
-              />
+          <div className='mb-8 px-[16px]'>
+            <div className='px-[1px]'>
+              <div className='relative h-2 bg-[var(--color-primary-200)] rounded-full'>
+                {/* Filled portion */}
+                <div
+                  className='absolute left-0 top-0 h-full bg-[var(--color-primary-500)] rounded-full'
+                  style={{ width: `${safeTemp}%` }}
+                />
+                {/* Indicator circle */}
+                <div
+                  className='absolute top-1/2 -translate-y-1/2 w-[23px] h-[23px] bg-[var(--color-primary-500)] rounded-full shadow-[0_0_10px_rgba(0,0,0,0.1)]'
+                  style={{ left: `calc(${safeTemp}% - 10px)` }}
+                />
+              </div>
             </div>
 
             {/* Labels */}
-            <div className='relative flex justify-between mt-2'>
+            <div className='relative flex justify-between mt-[6px]'>
               <span className='ty-body5 text-[var(--color-text-normal)]'>0도</span>
               <span
-                className='absolute ty-body5 text-[var(--color-primary-400)] -translate-x-1/2'
+                className='absolute ty-body5 text-[var(--color-primary-500)] -translate-x-1/2'
                 style={{ left: `${safeTemp}%` }}
               >
                 {safeTemp}도
@@ -120,7 +136,7 @@ const MyPage = () => {
           <div className='flex flex-col gap-4 mt-6'>
             <div className='flex items-center justify-between'>
               <div className='flex items-center gap-2'>
-                <HiPaperAirplane className='w-5 h-5 text-[var(--color-primary-400)] rotate-[-45deg]' />
+                <HiPaperAirplane className='w-5 h-5 text-[var(--color-primary-500)] rotate-[-45deg]' />
                 <span className='ty-body5 text-[var(--color-text-normal)]'>내가 보낸 편지</span>
               </div>
               <span className='ty-body4 text-[var(--color-text-normal)]'>
@@ -130,7 +146,7 @@ const MyPage = () => {
 
             <div className='flex items-center justify-between'>
               <div className='flex items-center gap-2'>
-                <HiEnvelope className='w-5 h-5 text-[var(--color-primary-400)]' />
+                <HiEnvelope className='w-5 h-5 text-[var(--color-primary-500)]' />
                 <span className='ty-body5 text-[var(--color-text-normal)]'>내가 받은 편지</span>
               </div>
               <span className='ty-body4 text-[var(--color-text-normal)]'>
@@ -140,7 +156,7 @@ const MyPage = () => {
 
             <div className='flex items-center justify-between'>
               <div className='flex items-center gap-2'>
-                <HiClock className='w-5 h-5 text-[var(--color-primary-400)]' />
+                <HiClock className='w-5 h-5 text-[var(--color-primary-500)]' />
                 <span className='ty-body5 text-[var(--color-text-normal)]'>서비스 총 이용시간</span>
               </div>
               <span className='ty-body4 text-[var(--color-text-normal)]'>

--- a/src/pages/my/MyPage.tsx
+++ b/src/pages/my/MyPage.tsx
@@ -30,8 +30,9 @@ const MyPage = () => {
   if (isLoading) return <div className='w-[375px] mx-auto py-20 text-center'>로딩 중...</div>;
   if (isError || !response)
     return <div className='w-[375px] mx-auto py-20 text-center'>데이터를 가져오지 못했습니다.</div>;
-  // 온도값을 0~100으로 clamp
-  const safeTemp = Math.max(0, Math.min(100, response.temperatureAvg));
+  // 온도값을 0~100으로 clamp(기본이 36.5)
+  const currentTemp = response?.temperatureAvg ?? 36.5;
+  const safeTemp = Math.max(0, Math.min(100, currentTemp));
 
   return (
     <div className='w-[375px] min-h-screen mx-auto bg-[var(--color-bg-500)]'>
@@ -89,7 +90,7 @@ const MyPage = () => {
           </div>
 
           <div className='flex gap-2 flex-wrap justify-center'>
-            {response.interests.map((item) => {
+            {(response.interests ?? []).map((item) => {
               const emoji = getInterestEmoji(item.id);
               return (
                 <span
@@ -132,7 +133,7 @@ const MyPage = () => {
                 className='absolute ty-body5 text-[var(--color-primary-500)] -translate-x-1/2'
                 style={{ left: `${safeTemp}%` }}
               >
-                {safeTemp}도
+                {safeTemp.toFixed(1)}도
               </span>
               {/* <span className='ty-body5 text-[var(--color-text-normal)]'>100도</span> */}
             </div>

--- a/src/pages/my/MyPage.tsx
+++ b/src/pages/my/MyPage.tsx
@@ -8,6 +8,7 @@ import { useNavigate } from 'react-router-dom';
 import { useActivityStore } from '@/stores/activityStore';
 import { useMyProfile } from '@/hooks/useMyProfile';
 import { ROUTES } from '@/routes/paths';
+import { getInterestEmoji } from '@/constants/interestUiMap';
 
 const MyPage = () => {
   const navigate = useNavigate();
@@ -82,7 +83,7 @@ const MyPage = () => {
             <h2 className='ty-body2 text-[var(--color-text-normal)]'>현재 나의 관심사</h2>
             <button
               type='button'
-              onClick={() => navigate('/onboarding/topic-select-2?mode=edit')} //라우팅 수정 필요!온보딩으로 이동이지만 확인 필요
+              onClick={() => navigate('/onboarding/topic-select-2?mode=edit')}
               className='flex items-center gap-1 ty-body5 text-[var(--color-text-assistive)]'
             >
               수정
@@ -91,14 +92,18 @@ const MyPage = () => {
           </div>
 
           <div className='flex gap-2 flex-wrap justify-center'>
-            {response.interests.map((item) => (
-              <span
-                key={item.id}
-                className='px-5 py-2 rounded-full border border-[var(--color-line-normal)] ty-body3 text-[var(--color-text-normal)]'
-              >
-                {item.name}
-              </span>
-            ))}
+            {response.interests.map((item) => {
+              const emoji = getInterestEmoji(item.id);
+              return (
+                <span
+                  key={item.id}
+                  className='px-5 py-2 rounded-full border border-[var(--color-line-normal)] ty-body3 text-[var(--color-text-normal)]'
+                >
+                  <span>{item.name}</span>
+                  <span aria-hidden>{emoji}</span>
+                </span>
+              );
+            })}
           </div>
         </section>
 

--- a/src/pages/my/MyPage.tsx
+++ b/src/pages/my/MyPage.tsx
@@ -13,7 +13,7 @@ import { useMemo } from 'react';
 
 const MyPage = () => {
   const navigate = useNavigate();
-  const handleProfilEedit = () => {
+  const handleProfileEdit = () => {
     return navigate(ROUTES.auth.profile);
   };
 
@@ -68,7 +68,7 @@ const MyPage = () => {
           <button
             type='button'
             className='flex-shrink-0 px-3 py-2 border border-[var(--color-line-normal)] rounded-xl ty-body5 text-[var(--color-text-normal)]'
-            onClick={handleProfilEedit}
+            onClick={handleProfileEdit}
           >
             프로필 수정
           </button>

--- a/src/pages/my/MyPage.tsx
+++ b/src/pages/my/MyPage.tsx
@@ -56,7 +56,7 @@ const MyPage = () => {
               />
             ) : (
               /* 이미지가 없을 때 보여줄 빈 화면 */
-              <div className='w-full h-full flex items-center justify-center text-[var(--color-primary-300)]'></div>
+              <div className='w-full h-full flex items-center justify-center text-[var(--color-primary-300)]' />
             )}
           </div>
 
@@ -148,7 +148,7 @@ const MyPage = () => {
                 <span className='ty-body5 text-[var(--color-text-normal)]'>내가 보낸 편지</span>
               </div>
               <span className='ty-body4 text-[var(--color-text-normal)]'>
-                {response.sentLettersCount}통
+                {response.sentLettersCount ?? 0}통
               </span>
             </div>
 
@@ -158,7 +158,7 @@ const MyPage = () => {
                 <span className='ty-body5 text-[var(--color-text-normal)]'>내가 받은 편지</span>
               </div>
               <span className='ty-body4 text-[var(--color-text-normal)]'>
-                {response.receivedLettersCount}통
+                {response.receivedLettersCount ?? 0}통
               </span>
             </div>
 

--- a/src/pages/my/MyPage.tsx
+++ b/src/pages/my/MyPage.tsx
@@ -26,7 +26,7 @@ const MyPage = () => {
   if (isError || !response)
     return <div className='w-[375px] mx-auto py-20 text-center'>데이터를 가져오지 못했습니다.</div>;
   // 온도값을 0~100으로 clamp
-  const safeTemp = Math.max(0, Math.min(100, 0));
+  const safeTemp = Math.max(0, Math.min(100, response.temperatureAvg));
 
   return (
     <div className='w-[375px] min-h-screen mx-auto bg-[var(--color-bg-500)]'>
@@ -82,7 +82,7 @@ const MyPage = () => {
             <h2 className='ty-body2 text-[var(--color-text-normal)]'>현재 나의 관심사</h2>
             <button
               type='button'
-              onClick={() => navigate('/onboarding/profile-select?mode=edit')}
+              onClick={() => navigate('/onboarding/topic-select-2?mode=edit')} //라우팅 수정 필요!온보딩으로 이동이지만 확인 필요
               className='flex items-center gap-1 ty-body5 text-[var(--color-text-assistive)]'
             >
               수정
@@ -125,14 +125,14 @@ const MyPage = () => {
 
             {/* Labels */}
             <div className='relative flex justify-between mt-[6px]'>
-              <span className='ty-body5 text-[var(--color-text-normal)]'>0도</span>
+              {/* <span className='ty-body5 text-[var(--color-text-normal)]'>0도</span> */}
               <span
                 className='absolute ty-body5 text-[var(--color-primary-500)] -translate-x-1/2'
                 style={{ left: `${safeTemp}%` }}
               >
                 {safeTemp}도
               </span>
-              <span className='ty-body5 text-[var(--color-text-normal)]'>100도</span>
+              {/* <span className='ty-body5 text-[var(--color-text-normal)]'>100도</span> */}
             </div>
           </div>
 

--- a/src/pages/onboarding/OnboardingTopicSelectPage.tsx
+++ b/src/pages/onboarding/OnboardingTopicSelectPage.tsx
@@ -8,8 +8,10 @@ import { useAllInterests } from '@/hooks/onboarding/useAllInterests';
 import { useMyInterests } from '@/hooks/onboarding/useMyInterests';
 import { useSaveInterests } from '@/hooks/onboarding/useSaveInterests';
 import { getInterestEmoji } from '@/constants/interestUiMap';
+import { useQueryClient } from '@tanstack/react-query';
 
 export default function OnboardingTopicSelectPage() {
+  const queryClient = useQueryClient();
   const navigate = useNavigate();
   const location = useLocation();
 
@@ -53,8 +55,9 @@ export default function OnboardingTopicSelectPage() {
     saveInterests.mutate(
       { interestIds: selectedArray },
       {
-        onSuccess: (res) => {
+        onSuccess: async (res) => {
           if (res.resultType === 'SUCCESS') {
+            await queryClient.invalidateQueries({ queryKey: ['myProfile'] }); // 마이페이지가 사용하는 데이터를 무효화하여 새로 가져옴
             if (isEdit) {
               navigate('/my/my-page', { replace: true });
             } else {

--- a/src/routes/paths.ts
+++ b/src/routes/paths.ts
@@ -14,4 +14,7 @@ export const ROUTES = {
   setting: {
     setting: '/setting',
   },
+  my: {
+    mypage: 'my/my-page',
+  },
 } as const;

--- a/src/routes/paths.ts
+++ b/src/routes/paths.ts
@@ -7,6 +7,7 @@ export const ROUTES = {
     signin: '/auth/signin',
     signup: '/auth/signup',
     terms: '/auth/terms',
+    profile: '/auth/profile-setup',
   },
   report: {
     keyword: '/report/keyword-letter',

--- a/src/routes/paths.ts
+++ b/src/routes/paths.ts
@@ -15,6 +15,6 @@ export const ROUTES = {
     setting: '/setting',
   },
   my: {
-    mypage: 'my/my-page',
+    mypage: '/my/my-page',
   },
 } as const;

--- a/src/types/dto/profile.ts
+++ b/src/types/dto/profile.ts
@@ -9,7 +9,7 @@ export interface MyProfileResult {
   id: string;
   nickname: string;
   email: string;
-  profileImageUrl: string;
+  profileImageUrl: string | null;
   interests: Interest[];
   sentLettersCount: number;
   receivedLettersCount: number;

--- a/src/types/dto/profile.ts
+++ b/src/types/dto/profile.ts
@@ -1,0 +1,19 @@
+import type { CommonResponse } from './common';
+
+export interface Interest {
+  id: number;
+  name: string;
+}
+
+export interface MyProfileResult {
+  id: string;
+  nickname: string;
+  email: string;
+  profileImageUrl: string;
+  interests: Interest[];
+  sentLettersCount: number;
+  receivedLettersCount: number;
+  temperatureAvg: number;
+  totalUsageMinutes: number;
+}
+export type MyProfileResponse = CommonResponse<MyProfileResult>;


### PR DESCRIPTION
## 📂 관련 이슈

- closes #145 

---마이페이지 API 연동 및 프로필 수정 API 로직 수정

## 🛠️ 작업 사항

- [x] 마이페이지 사용자 프로필 API 연동
- [x] 마이페이지 키워드 박스 API 연동
- [x] 마이페이지 나의 온도 박스 API 연동
- [x] 프로필 수정페이지 이미지 및 닉네임 수정 API 로직 수정
- [x]  마이페이지 관심사 수정 시 관심사 로직 수정

---

## 📸 관련 이미지 (스크린샷 또는 동영상)

---
<img width="355" height="867" alt="image" src="https://github.com/user-attachments/assets/1565c6b1-e608-405d-b47b-1eab81863304" />



## 💬 기타 설명

> 💡 추가적으로 공유할 내용이나 리뷰어에게 전달할 사항이 있다면 작성해 주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 내 프로필 조회(프로필 이미지, 닉네임, 이메일, 관심사, 통계) 및 프로필 조회용 훅 추가
  * 프로필 설정 페이지(신규/편집) 흐름 지원 및 편집 완료 시 경로 분기(마이페이지/온보딩)
  * 마이페이지에서 프로필 편집 이동 기능 추가

* **개선사항**
  * 프로필 이미지 캐시 무효화(캐시버스터)로 즉시 반영 보장
  * 프로필 관련 변경 시 데이터 동기화를 위한 쿼리 무효화 추가
  * 마이페이지에 로딩·오류 처리 및 실시간 데이터 반영 적용
<!-- end of auto-generated comment: release notes by coderabbit.ai -->