### PR TITLE
바텀시트 스크롤 끊김 현상 해결

### DIFF
--- a/src/components/BottomSheet/BottomSheet.tsx
+++ b/src/components/BottomSheet/BottomSheet.tsx
@@ -84,14 +84,16 @@ export default function BottomSheet({
     setCurrentHeight(clamped);
   };
 
-  const onPointerUpHandle = (e: React.PointerEvent) => {
+  const endDrag = (e: React.PointerEvent) => {
     if (!draggable || !hasFixedHeight) return;
 
+    setIsDragging(false);
     dragRef.current = null;
+
     try {
       (e.currentTarget as HTMLElement).releasePointerCapture(e.pointerId);
     } catch {
-      // ignore: pointer capture may already be released
+      // ignore
     }
   };
 
@@ -113,25 +115,33 @@ export default function BottomSheet({
       {/* BottomSheet */}
       <div
         ref={sheetRef}
-        className='fixed bottom-0 left-1/2 -translate-x-1/2 bg-white rounded-t-2xl z-50 transform transition-transform duration-300 ease-out'
+        className={[
+          'fixed bottom-0 left-1/2 -translate-x-1/2 bg-white rounded-t-2xl z-50',
+          'transition-transform duration-300 ease-out',
+          isOpen ? 'translate-y-0' : 'translate-y-full',
+        ].join(' ')}
         style={{
           width: '375px',
           maxWidth: '100vw',
           height: hasFixedHeight ? currentHeight : 'auto',
-          // maxHeight: hasFixedHeight ? currentHeight : undefined,
-          // 젠: 빌드 오류 고치기 위해 임의로 수정했습니다! 나중에 이 부분 수정 하시면서 확인해주세요~
           maxHeight: hasFixedHeight ? maxHeightPx : undefined,
 
-          animation: 'slideUp 0.3s ease-out',
           boxShadow: '0 -4px 15px rgba(0, 0, 0, 0.12)',
+
+          willChange: 'transform',
         }}
       >
         {/* 드래그 핸들 */}
         <div
           className='flex justify-center py-3 cursor-grab'
+          style={{
+            // pointer 이벤트는 드래그에 집중 (핸들에서만)
+            touchAction: 'none',
+          }}
           onPointerDown={onPointerDownHandle}
           onPointerMove={onPointerMoveHandle}
-          onPointerUp={onPointerUpHandle}
+          onPointerUp={endDrag}
+          onPointerCancel={endDrag}
         >
           <div className='w-14 h-1 bg-[var(--color-text-assistive)] rounded-full' />
         </div>
@@ -149,22 +159,15 @@ export default function BottomSheet({
           style={{
             height: contentHeight,
             overflow: isDragging ? 'hidden' : 'auto',
+
+            WebkitOverflowScrolling: 'touch',
+            overscrollBehavior: 'contain',
+            touchAction: 'pan-y',
           }}
         >
           {children}
         </div>
       </div>
-
-      <style>{`
-        @keyframes slideUp {
-          from {
-            transform: translateY(100%);
-          }
-          to {
-            transform: translateY(0);
-          }
-        }
-      `}</style>
     </>
   );
 }

--- a/src/components/BottomSheet/letterStyle/LetterStyleContent.tsx
+++ b/src/components/BottomSheet/letterStyle/LetterStyleContent.tsx
@@ -87,7 +87,7 @@ export default function LetterStyleContent({
               onClick={() => onChange?.({ paperId: p.id })}
               className={[
                 'relative overflow-hidden shadow-md transition-all duration-200',
-                'scale-90 -rotate-2',
+                'scale-80 -rotate-2',
               ].join(' ')}
               style={
                 value.paperId === p.id

--- a/src/components/BottomSheet/letterStyle/LetterStyleContent.tsx
+++ b/src/components/BottomSheet/letterStyle/LetterStyleContent.tsx
@@ -79,7 +79,7 @@ export default function LetterStyleContent({
 
       {/* 편지지 그리드 뷰 */}
       {selectedTab === 'paper' && (
-        <div className='grid grid-cols-3 gap-4'>
+        <div className='grid grid-cols-3 gap-2'>
           {paperViewModels.map((p) => (
             <button
               key={p.id}

--- a/src/components/BottomSheet/letterStyle/StyleTabs.tsx
+++ b/src/components/BottomSheet/letterStyle/StyleTabs.tsx
@@ -8,7 +8,7 @@ type StyleTabProps = {
 
 const StyleTabs = ({ selectedTab, onChangeTab }: StyleTabProps) => {
   return (
-    <div className='sticky top-0 z-10 bg-white'>
+    <div className='sticky top-0 z-10 bg-white pt-1 pb-0.5'>
       <div className='flex justify-center gap-23 mb-7'>
         <button
           onClick={() => onChangeTab('font')}
@@ -25,8 +25,8 @@ const StyleTabs = ({ selectedTab, onChangeTab }: StyleTabProps) => {
           onClick={() => onChangeTab('paper')}
           className={
             selectedTab === 'paper'
-              ? 'ty-body3 text-[var(--color-primary-500)]'
-              : 'ty-body3 text-black/40'
+              ? 'ty-body3 text-[var(--color-primary-500)] mr-1'
+              : 'ty-body3 text-black/40 mr-1'
           }
         >
           색상
@@ -36,8 +36,8 @@ const StyleTabs = ({ selectedTab, onChangeTab }: StyleTabProps) => {
           onClick={() => onChangeTab('stamp')}
           className={
             selectedTab === 'stamp'
-              ? 'ty-body3 text-[var(--color-primary-500)]'
-              : 'ty-body3 text-black/40'
+              ? 'ty-body3 text-[var(--color-primary-500)] mr-1'
+              : 'ty-body3 text-black/40 mr-1'
           }
         >
           우표

--- a/src/components/BottomSheet/letterStyle/StyleTabs.tsx
+++ b/src/components/BottomSheet/letterStyle/StyleTabs.tsx
@@ -8,7 +8,7 @@ type StyleTabProps = {
 
 const StyleTabs = ({ selectedTab, onChangeTab }: StyleTabProps) => {
   return (
-    <div className='sticky top-0 z-10 bg-white pt-1'>
+    <div className='sticky top-0 z-10 bg-white'>
       <div className='flex justify-center gap-23 mb-7'>
         <button
           onClick={() => onChangeTab('font')}

--- a/src/pages/letter/LetterDecoPage.tsx
+++ b/src/pages/letter/LetterDecoPage.tsx
@@ -79,6 +79,30 @@ function LetterDecoPage() {
   }, []);
   const closeSheet = () => setIsOpen(false);
 
+  // body를 고정해서 배경 스크롤 막기
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const scrollY = window.scrollY;
+
+    document.body.style.position = 'fixed';
+    document.body.style.top = `-${scrollY}px`;
+    document.body.style.left = '0';
+    document.body.style.right = '0';
+    document.body.style.width = '100%';
+
+    return () => {
+      const y = Math.abs(parseInt(document.body.style.top || '0', 10));
+      document.body.style.position = '';
+      document.body.style.top = '';
+      document.body.style.left = '';
+      document.body.style.right = '';
+      document.body.style.width = '';
+
+      window.scrollTo(0, y);
+    };
+  }, [isOpen]);
+
   // 잘못된 접근 방어 (URL로 직접 접근, 작성 흐름 없이 들어온 경우)
   useEffect(() => {
     if (!safeMode) {


### PR DESCRIPTION
## 📂 관련 이슈

- closes #147 

---

## 🛠️ 작업 사항

- [x] 데코페이지 스크롤 막기
- [x] 바텀시트 내부 수정 - 이벤트 경로 통합으로 스크롤 끊김 현상 해결

---

## 📸 관련 이미지 (스크린샷 또는 동영상)

https://github.com/user-attachments/assets/585bc446-714f-497f-92ca-d4e7a22982b7

---

## 💬 기타 설명


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 하단 시트의 드래그 및 포인터/터치 이벤트 처리 개선
  * 하단 시트의 열림/닫힘 동작을 더 일관된 변환 기반으로 변경(애니메이션 안정화)
  * 하단 시트가 열릴 때 배경 스크롤 방지(페이지 고정 처리)
  * 종이 선택 옵션의 아이템 크기 및 간격 조정
  * 스타일 탭의 버튼 간 여백 최적화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->