### PR TITLE
[Feat] 익명 랜덤 닉네임 발급, 메인페이지/피드 스타일 컨벤션 통일

### DIFF
--- a/src/components/common/FloatingButton.tsx
+++ b/src/components/common/FloatingButton.tsx
@@ -51,8 +51,7 @@ export default function FloatingButton({
           justifyContent: 'center',
           paddingTop: '16px',
           paddingBottom: '16px',
-          boxShadow:
-            '0px 0px 10px rgba(0, 0, 0, 0.1), 0px 4px 4px rgba(0, 0, 0, 0.25)',
+          boxShadow: '0px 0px 10px rgba(0, 0, 0, 0.1), 0px 4px 4px rgba(0, 0, 0, 0.25)',
           pointerEvents: 'auto',
         }}
       >

--- a/src/components/common/QuestionCard.tsx
+++ b/src/components/common/QuestionCard.tsx
@@ -14,12 +14,7 @@ export default function QuestionCard({ question, timeLeft, profileImageUrl }: Qu
   };
 
   return (
-    <div
-      className='w-full px-4 py-2.5'
-      style={{
-        backgroundColor: '#FAFAFA', // rgb(250, 250, 250) - 피그마: rgb(0.98, 0.98, 0.98)
-      }}
-    >
+    <div className='w-full px-4 py-2.5 bg-[var(--color-bg-primary)]'>
       <div className='flex items-center gap-10'>
         {/* 질문 텍스트 영역 */}
         <div className='flex-1 flex flex-col gap-2'>

--- a/src/components/common/QuestionCard.tsx
+++ b/src/components/common/QuestionCard.tsx
@@ -1,3 +1,5 @@
+import { useNavigate } from 'react-router-dom';
+
 interface QuestionCardProps {
   question: string;
   timeLeft: string;
@@ -5,6 +7,12 @@ interface QuestionCardProps {
 }
 
 export default function QuestionCard({ question, timeLeft, profileImageUrl }: QuestionCardProps) {
+  const navigate = useNavigate();
+
+  const handleClick = () => {
+    navigate('/my/my-page');
+  };
+
   return (
     <div
       className='w-full px-4 py-2.5'
@@ -19,24 +27,9 @@ export default function QuestionCard({ question, timeLeft, profileImageUrl }: Qu
           <h2 className='whitespace-pre-line ty-title2'>{question}</h2>
 
           {/* 타이머 */}
-          <p
-            style={{
-              fontFamily: 'Pretendard',
-              fontWeight: 500,
-              fontSize: '16px',
-              lineHeight: '25.6px',
-              color: '#000000',
-            }}
-          >
-            <span
-              style={{
-                fontWeight: 600,
-                color: '#F22619', // rgb(242, 38, 25) - 피그마: rgb(0.950, 0.150, 0.110)
-              }}
-            >
-              {timeLeft}
-            </span>{' '}
-            후에 질문이 사라져요.
+          <p className='ty-body2 text-[var(--color-primary-heavy)]'>
+            <span className='text-[var(--color-primary-500)]'>{timeLeft}</span> 후에 질문이
+            사라져요.
           </p>
         </div>
 
@@ -50,7 +43,12 @@ export default function QuestionCard({ question, timeLeft, profileImageUrl }: Qu
               border: '0.5px solid #E2E2E2',
             }}
           >
-            <img src={profileImageUrl} alt='프로필' className='w-full h-full object-cover' />
+            <img
+              src={profileImageUrl}
+              alt='프로필'
+              className='w-full h-full object-cover cursor-pointer'
+              onClick={handleClick}
+            />
           </div>
         )}
       </div>

--- a/src/components/letters/LetterItem.tsx
+++ b/src/components/letters/LetterItem.tsx
@@ -1,6 +1,6 @@
 import { DEFAULT_THEME, makeEnvelopeLineColor, PAPER_THEME } from '@/constants/paperTheme';
 import type { FeedLetter } from '@/types/letter';
-import { getParseDate } from '@/utils/date';
+import { formatDate } from '@/utils/date';
 
 interface LetterItemProps {
   letter: FeedLetter;
@@ -89,7 +89,7 @@ export default function LetterItem({ letter, onClick }: LetterItemProps) {
               whiteSpace: 'nowrap',
             }}
           >
-            {getParseDate(letter.deliveredAt)}
+            {formatDate(letter.deliveredAt)}
           </p>
         </div>
       </div>

--- a/src/pages/feed/FriendFeedPage.tsx
+++ b/src/pages/feed/FriendFeedPage.tsx
@@ -69,7 +69,7 @@ export default function FriendFeedPage() {
   const formattedQuestionText = (questionData?.content ?? '').replace(/^질문\s*#\d+:\s*/, '');
 
   return (
-    <div className='min-h-dvh pb-24' style={{ backgroundColor: '#FAFAFA' }}>
+    <div className='min-h-dvh pb-24 bg-[var(--color-bg-500)]'>
       {/* 고정 상단바 */}
       <FeedHeader title='친구 편지' />
 
@@ -78,12 +78,12 @@ export default function FriendFeedPage() {
 
       {/* 상단 질문 섹션 */}
       <div className='flex flex-col items-start p-5 -mt-3 gap-2'>
-        <p className='text-black ty-title2 w-[251px] whitespace-pre-line'>
+        <p className='text-[var(--color-primary-heavy)] ty-title2 w-[251px] whitespace-pre-line'>
           {formattedQuestionText}
         </p>
         <div className='flex items-center ty-body2'>
-          <span className='text-[#F2261C]'>{mmss}</span>
-          <span className='text-black ml-1'>후에 질문이 사라져요.</span>
+          <span className='text-[var(--color-primary-500)]'>{mmss}</span>
+          <span className='text-[var(--color-primary-heavy)] ml-1'>후에 질문이 사라져요.</span>
         </div>
       </div>
 
@@ -105,7 +105,7 @@ export default function FriendFeedPage() {
       </section>
 
       {/* 플로팅 버튼 */}
-      <FloatingButton text='나도 편지 작성하기' navigateTo='/write' />
+      <FloatingButton text='나도 편지 작성하기' navigateTo='/friend/inbox' />
     </div>
   );
 }

--- a/src/pages/feed/PublicFeedPage.tsx
+++ b/src/pages/feed/PublicFeedPage.tsx
@@ -69,7 +69,7 @@ export default function FeedPage() {
   const formattedQuestionText = (questionData?.content ?? '').replace(/^질문\s*#\d+:\s*/, '');
 
   return (
-    <div className='min-h-dvh pb-24' style={{ backgroundColor: '#FAFAFA' }}>
+    <div className='min-h-dvh pb-24 bg-[var(--color-bg-500)]'>
       {/* 고정 상단바 */}
       <FeedHeader title='공개 편지' />
 
@@ -78,12 +78,12 @@ export default function FeedPage() {
 
       {/* 상단 질문 섹션 */}
       <div className='flex flex-col items-start p-5 -mt-3 gap-2'>
-        <p className='text-black ty-title2 w-[251px] whitespace-pre-line'>
+        <p className='text-[var(--color-primary-heavy)] ty-title2 w-[251px] whitespace-pre-line'>
           {formattedQuestionText}
         </p>
         <div className='flex items-center ty-body2'>
-          <span className='text-[#F2261C]'>{mmss}</span>
-          <span className='text-black ml-1'>후에 질문이 사라져요.</span>
+          <span className='text-[var(--color-primary-500)]'>{mmss}</span>
+          <span className='text-[var(--color-primary-heavy)] ml-1'>후에 질문이 사라져요.</span>
         </div>
       </div>
 

--- a/src/pages/friend/FriendInboxPage.tsx
+++ b/src/pages/friend/FriendInboxPage.tsx
@@ -7,7 +7,7 @@ import { AiOutlineSearch } from 'react-icons/ai';
 import SortIcon from '@/assets/icons/SortIcon.svg?react';
 import { useFriends } from '@/hooks/friend/useFriend';
 import { ENVELOPE_ASSET_MAP } from '@/constants/envelopeAssets';
-import { getParseDate } from '@/utils/date';
+import { formatDate } from '@/utils/date';
 
 type FriendInboxItem = {
   id: number;
@@ -42,7 +42,7 @@ export default function FriendInboxPage() {
           name: (f.nickname ?? '').trim(),
           exchangeCount: f.letterCount,
 
-          lastDate: iso ? getParseDate(iso) : '-', // UI용
+          lastDate: iso ? formatDate(iso) : '-', // UI용
           lastAtMs: Number.isNaN(ms) ? 0 : ms, // 정렬용
 
           paperId: Number((f.recentLetter?.design.paper?.id ?? 0) + 1),

--- a/src/pages/friend/FriendPostPage.tsx
+++ b/src/pages/friend/FriendPostPage.tsx
@@ -8,7 +8,7 @@ import NotFoundPage from '../system/NotFoundPage';
 import { LoadingDots } from '@/components/LoadingDots';
 import { Button } from '@/components/common/Button';
 import { ENVELOPE_ASSET_MAP } from '@/constants/envelopeAssets';
-import { getParseDate } from '@/utils/date';
+import { formatDate } from '@/utils/date';
 
 type Direction = 'received' | 'sent';
 
@@ -45,7 +45,7 @@ export default function FriendPostPage() {
       letterId: l.id,
       title: l.title,
       deliveredAt: l.deliveredAt,
-      dateText: getParseDate(l.deliveredAt),
+      dateText: formatDate(l.deliveredAt),
       direction: 'received',
       isUnread: l.readAt === null,
       paperId: (l.design.paper.id ?? 0) + 1,
@@ -57,7 +57,7 @@ export default function FriendPostPage() {
       letterId: l.id,
       title: l.title,
       deliveredAt: l.deliveredAt,
-      dateText: getParseDate(l.deliveredAt),
+      dateText: formatDate(l.deliveredAt),
       direction: 'sent',
       isUnread: false,
       paperId: (l.design.paper.id ?? 0) + 1,

--- a/src/pages/letter/AnonDraftPage.tsx
+++ b/src/pages/letter/AnonDraftPage.tsx
@@ -106,12 +106,12 @@ const AnonDraftPage = () => {
           </>
         ) : (
           <>
-            <p className='text-black ty-title2 w-[251px] whitespace-pre-line'>
+            <p className='text-[var(--color-primary-heavy)] ty-title2 w-[251px] whitespace-pre-line'>
               {formattedQuestionText}
             </p>
             <div className='flex items-center ty-body2'>
-              <span className='text-[#F2261C]'>{mmss}</span>
-              <span className='text-black ml-1'>후에 질문이 사라져요.</span>
+              <span className='text-[var(--color-primary-500)]'>{mmss}</span>
+              <span className='text-[var(--color-primary-heavy)] ml-1'>후에 질문이 사라져요.</span>
             </div>
           </>
         )}

--- a/src/pages/letter/LetterInboxOtherPage.tsx
+++ b/src/pages/letter/LetterInboxOtherPage.tsx
@@ -11,7 +11,8 @@ import { LoadingDots } from '@/components/LoadingDots';
 import { Button } from '@/components/common/Button';
 import { ENVELOPE_ASSET_MAP } from '@/constants/envelopeAssets';
 import { useThreadFlowStore } from '@/stores/letterContextStore';
-import { getParseDate } from '@/utils/date';
+import { formatDate } from '@/utils/date';
+import { getAnonNickname } from '@/utils/anonNickname';
 
 type SortOrder = 'latest' | 'oldest';
 
@@ -51,8 +52,8 @@ export default function LetterInboxOtherPage() {
         sessionId: x.sessionId,
         senderId: x.sender.id,
         question: x.lastLetterTitle,
-        senderName: x.sender.nickname,
-        receivedAt: getParseDate(deliveredAt),
+        senderName: getAnonNickname(x.sender.id),
+        receivedAt: formatDate(deliveredAt),
         receivedAtMs: new Date(deliveredAt).getTime(),
         letterCount: x.sender.letterCount,
         isUnread: false,

--- a/src/pages/letter/LetterInboxOtherPage.tsx
+++ b/src/pages/letter/LetterInboxOtherPage.tsx
@@ -21,7 +21,7 @@ type InboxOtherLetterItem = {
   sessionId: number;
   senderId: number; // 상대방 userId (신고/차단 시 필요)
   question: string;
-  senderName: string; // 랜덤 익명 닉네임 (TODO : 유틸 함수 사용해서 발급 필요)
+  senderName: string; // 랜덤 익명 닉네임
   receivedAt: string; // 화면 표시용 (YYYY.MM.DD)
   receivedAtMs: number; // Sorting용
   letterCount: number;
@@ -109,6 +109,7 @@ export default function LetterInboxOtherPage() {
       <main className='px-5 pb-[95px]'>
         <div className='mx-auto w-full max-w-[343px]'>
           <LetterInboxTabs value={tab} onChange={handleTabChange} />
+
           {/* 검색 */}
           <div className='mt-[16px] flex items-center gap-3'>
             <div className='flex h-11 flex-1 w-[229px] items-center gap-2 rounded-xl bg-[var(--color-bg-secondary)] px-4'>

--- a/src/pages/letter/LetterInboxSelfPage.tsx
+++ b/src/pages/letter/LetterInboxSelfPage.tsx
@@ -10,6 +10,7 @@ import { useSelfMailbox } from '@/hooks/mails/useSelfMailbox';
 import { LoadingDots } from '@/components/LoadingDots';
 import { Button } from '@/components/common/Button';
 import { ENVELOPE_ASSET_MAP } from '@/constants/envelopeAssets';
+import { formatDate } from '@/utils/date';
 
 type SortOrder = 'latest' | 'oldest';
 
@@ -23,19 +24,6 @@ type InboxSelfLetterItem = {
   paperId: number;
   stampId: number; // TODO : 백엔드 필드 수정 후 연동 필요
   stampUrl: string;
-};
-
-const parseDate = (input: string | null | undefined) => {
-  if (!input) return '-';
-
-  const d = new Date(input);
-  if (Number.isNaN(d.getTime())) return '-';
-
-  const y = d.getFullYear();
-  const m = String(d.getMonth() + 1).padStart(2, '0');
-  const day = String(d.getDate()).padStart(2, '0');
-
-  return `${y}.${m}.${day}`;
 };
 
 export default function LetterInboxSelfPage() {
@@ -54,7 +42,7 @@ export default function LetterInboxSelfPage() {
       letterId: x.id,
       questionId: x.questionId,
       title: x.title,
-      receivedAt: parseDate(x.createdAt),
+      receivedAt: formatDate(x.createdAt),
       receivedAtMs: new Date(x.createdAt).getTime(),
       isUnread: false,
       paperId: x.paperId + 1,

--- a/src/pages/letter/LetterInboxSelfPage.tsx
+++ b/src/pages/letter/LetterInboxSelfPage.tsx
@@ -16,13 +16,13 @@ type SortOrder = 'latest' | 'oldest';
 
 type InboxSelfLetterItem = {
   letterId: number;
-  questionId: number; // TODO : 백엔드 필드 수정 후 연동 필요
+  questionId: number;
   title: string;
   receivedAt: string; // 화면 표시용 (YYYY.MM.DD)
   receivedAtMs: number; // Sorting용
   isUnread: boolean;
   paperId: number;
-  stampId: number; // TODO : 백엔드 필드 수정 후 연동 필요
+  stampId: number;
   stampUrl: string;
 };
 
@@ -124,7 +124,7 @@ export default function LetterInboxSelfPage() {
                 </Button>
               </div>
             ) : /* 3) 비었을 때 */ isEmpty ? (
-              <div className='mt-4 flex items-center justify-center py-[180px] ty-body3 text-[var(--color-text-assistive)]'>
+              <div className='mt-8 flex items-center justify-center py-[180px] ty-body3 text-[var(--color-text-assistive)]'>
                 검색 결과가 없어요
               </div>
             ) : (

--- a/src/pages/letter/LetterPostOtherPage.tsx
+++ b/src/pages/letter/LetterPostOtherPage.tsx
@@ -9,7 +9,7 @@ import { Button } from '@/components/common/Button';
 import { LoadingDots } from '@/components/LoadingDots';
 import { ENVELOPE_ASSET_MAP } from '@/constants/envelopeAssets';
 import { useThreadFlowStore } from '@/stores/letterContextStore';
-import { getParseDate } from '@/utils/date';
+import { formatDate } from '@/utils/date';
 
 type PostItem = {
   letterId: number;
@@ -42,7 +42,7 @@ export default function LetterPostOtherPage() {
       letterId: l.id,
       title: l.title,
       deliveredAt: l.deliveredAt,
-      dateText: getParseDate(l.deliveredAt),
+      dateText: formatDate(l.deliveredAt),
       isMine: l.isMine,
       isUnread: l.readAt === null,
       paperId: l.design?.paperId ?? 0,

--- a/src/pages/letter/LetterReplyPage.tsx
+++ b/src/pages/letter/LetterReplyPage.tsx
@@ -71,6 +71,8 @@ export default function LetterReplyPage() {
     return stripQuestionPrefix(q);
   }, [view?.question, data?.question]);
 
+  const remainingCount = useMemo(() => Math.max(0, 10 - letterCount), [letterCount]);
+
   const assets = useMemo(() => {
     if (!view) return null;
 
@@ -98,12 +100,10 @@ export default function LetterReplyPage() {
   };
 
   const handleReply = () => {
-    navigate('/letter/other/draft');
+    navigate('/letter/other/draft', { state: { remainingCount } });
   };
 
   const handleEnd = () => {
-    const remainingCount = Math.max(0, 10 - letterCount);
-
     openModal('conversationRemaining', {
       friendName: senderName,
       remainingCount,

--- a/src/pages/letter/OtherDraftPage.tsx
+++ b/src/pages/letter/OtherDraftPage.tsx
@@ -109,7 +109,7 @@ const OtherDraftPage = () => {
       />
       <div className='flex flex-col items-start p-4 -mt-3 gap-3'>
         <div className='ty-title3'>
-          <span className='text-black'>우리에게 남은 편지 횟수는 </span>
+          <span className='text-[var(--color-primary-heavy)]'>우리에게 남은 편지 횟수는 </span>
           <span className='text-[var(--color-primary-500)]'>{letterLeft}회</span>
         </div>
         {/* daily question */}

--- a/src/pages/letter/OtherDraftPage.tsx
+++ b/src/pages/letter/OtherDraftPage.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 import BackHeader from '@/components/common/headers/BackHeader';
 import ToggleSwitch from '@/components/common/ToggleSwitch';
@@ -33,8 +33,8 @@ const OtherDraftPage = () => {
   // SenderName 불러오기
   const senderName = useThreadFlowStore((s) => s.senderName) ?? '익명';
 
-  // TODO : 남은 편지 횟수 처리 필요
-  const letterLeft = 4;
+  const { state } = useLocation();
+  const remainingCount = state?.remainingCount ?? 0;
 
   // questionId 저장
   useEffect(() => {
@@ -110,7 +110,7 @@ const OtherDraftPage = () => {
       <div className='flex flex-col items-start p-4 -mt-3 gap-3'>
         <div className='ty-title3'>
           <span className='text-[var(--color-primary-heavy)]'>우리에게 남은 편지 횟수는 </span>
-          <span className='text-[var(--color-primary-500)]'>{letterLeft}회</span>
+          <span className='text-[var(--color-primary-500)]'>{remainingCount}회</span>
         </div>
         {/* daily question */}
         <DailyQuestionBox

--- a/src/pages/letter/SelfDraftPage.tsx
+++ b/src/pages/letter/SelfDraftPage.tsx
@@ -204,12 +204,12 @@ const SelfDraftPage = () => {
           </>
         ) : (
           <>
-            <p className='text-black ty-title2 w-[251px] whitespace-pre-line'>
+            <p className='text-[var(--color-primary-heavy)] ty-title2 w-[251px] whitespace-pre-line'>
               {formattedQuestionText}
             </p>
             <div className='flex items-center ty-body2'>
-              <span className='text-[#F2261C]'>{mmss}</span>
-              <span className='text-black ml-1'>후에 질문이 사라져요.</span>
+              <span className='text-[var(--color-primary-500)]'>{mmss}</span>
+              <span className='text-[var(--color-primary-heavy)] ml-1'>후에 질문이 사라져요.</span>
             </div>
           </>
         )}

--- a/src/pages/main/LetterJourney.tsx
+++ b/src/pages/main/LetterJourney.tsx
@@ -21,18 +21,8 @@ export default function LetterJourney({
   return (
     <div className='w-full px-4 py-2.5'>
       {/* 헤더 */}
-      <div className='flex items-center justify-between mb-3'>
-        <h3
-          style={{
-            fontFamily: 'Pretendard',
-            fontWeight: 600,
-            fontSize: '16px',
-            lineHeight: '25.6px',
-            color: '#000000',
-          }}
-        >
-          {userName}의 편지 여행
-        </h3>
+      <div className='flex items-center justify-between mb-3 ty-body2 text-[var(--color-text-normal)]'>
+        {userName}의 편지 여행
       </div>
 
       {/* 전체 컨테이너 */}
@@ -73,23 +63,8 @@ export default function LetterJourney({
 
         {/* 기간 태그 */}
         <div className='mb-[5px]'>
-          <div
-            className='inline-block px-2.5 py-0.5 rounded-2xl'
-            style={{
-              backgroundColor: '#F55449', // rgb(245, 84, 73)
-            }}
-          >
-            <span
-              style={{
-                fontFamily: 'Pretendard',
-                fontWeight: 400,
-                fontSize: '12px',
-                lineHeight: '19.2px',
-                color: '#FFFFFF',
-              }}
-            >
-              {weekLabel}
-            </span>
+          <div className='inline-block px-2.5 py-0.5 rounded-2xl bg-[var(--color-primary-500)]'>
+            <span className='ty-detailMedium text-white'>{weekLabel}</span>
           </div>
         </div>
 
@@ -104,94 +79,33 @@ export default function LetterJourney({
           >
             {/* 내가 받은 편지 */}
             <div className='flex items-center gap-1.5'>
-              <span
-                style={{
-                  fontFamily: 'Pretendard',
-                  fontWeight: 400,
-                  fontSize: '12px',
-                  lineHeight: '19.2px',
-                  color: '#000000',
-                }}
-              >
+              <span className='ty-detailMedium text-[var(--color-text-normal)]'>
                 내가 받은 편지
               </span>
-              <span
-                style={{
-                  fontFamily: 'Pretendard',
-                  fontWeight: 600,
-                  fontSize: '14px',
-                  lineHeight: '23.8px',
-                  color: '#F55449',
-                }}
-              >
-                {receivedCount}통
-              </span>
+              <span className='ty-body4 text-[var(--color-primary-500)]'>{receivedCount}통</span>
             </div>
 
             {/* 내가 보낸 편지 */}
             <div className='flex items-center gap-1.5'>
-              <span
-                style={{
-                  fontFamily: 'Pretendard',
-                  fontWeight: 400,
-                  fontSize: '12px',
-                  lineHeight: '19.2px',
-                  color: '#000000',
-                }}
-              >
+              <span className='ty-detailMedium text-[var(--color-text-normal)]'>
                 내가 보낸 편지
               </span>
-              <span
-                style={{
-                  fontFamily: 'Pretendard',
-                  fontWeight: 600,
-                  fontSize: '14px',
-                  lineHeight: '23.8px',
-                  color: '#F55449',
-                }}
-              >
-                {sentCount}통
-              </span>
+              <span className='ty-body4 text-[var(--color-primary-500)]'>{sentCount}통</span>
             </div>
           </div>
 
           {/* 총 편지 수 */}
           <div className='flex items-center justify-center gap-1.5 py-1 mt-1'>
-            <span
-              style={{
-                fontFamily: 'Pretendard',
-                fontWeight: 600,
-                fontSize: '14px',
-                lineHeight: '23.8px',
-                color: '#000000',
-              }}
-            >
-              그동안 내가 보낸 편지
-            </span>
-            <span
-              style={{
-                fontFamily: 'Pretendard',
-                fontWeight: 600,
-                fontSize: '16px',
-                lineHeight: '25.6px',
-                color: '#F55449',
-              }}
-            >
-              총 {totalCount}통
-            </span>
+            <span className='ty-body4 text-[var(--color-text-normal)]'>그동안 내가 보낸 편지</span>
+            <span className='ty-body2 text-[var(--color-primary-500)]'>총 {totalCount}통</span>
           </div>
         </div>
 
         {/* 진행 메시지 */}
         <div className='flex items-center justify-center gap-2 mt-1'>
           <p
-            className='text-center'
+            className='text-center ty-detailMedium text-[var(--color-text-alternative)]'
             style={{
-              fontFamily: 'Pretendard',
-              fontWeight: 400,
-              fontSize: '12px',
-              lineHeight: '19.2px',
-              color: '#595959',
               maxWidth: '219px',
               whiteSpace: 'pre-line',
             }}
@@ -199,7 +113,7 @@ export default function LetterJourney({
             {progressMessage}
           </p>
           <div className='flex-shrink-0'>
-            <IoPlanet size={24} color='#F55449' />
+            <IoPlanet className='w-6 h-6 text-[var(--color-primary-500)]' />
           </div>
         </div>
       </div>

--- a/src/pages/main/Mainpage.tsx
+++ b/src/pages/main/Mainpage.tsx
@@ -133,14 +133,7 @@ const MainPage = () => {
         </div>
 
         {/* 편지 캐러셀 */}
-        <LetterCarousel
-          letters={otherLetters}
-          emptyMessage='현재 공개된 편지가 더이상 없어요.'
-          onLetterClick={(l) => {
-            // TODO : 캐러셀 눌렀을 때 어디로 이동하는지 주소 재확인
-            console.log('public letter click:', l.letterId);
-          }}
-        />
+        <LetterCarousel letters={otherLetters} emptyMessage='현재 공개된 편지가 더이상 없어요.' />
       </section>
 
       {/* 친구 편지 섹션 */}
@@ -166,14 +159,7 @@ const MainPage = () => {
         </div>
 
         {/* 편지 캐러셀 */}
-        <LetterCarousel
-          letters={friendLetters}
-          emptyMessage='친구의 편지가 아직 없어요.'
-          onLetterClick={(l) => {
-            // TODO : 캐러셀 눌렀을 때 어디로 이동하는지 주소 재확인
-            console.log('friend letter click:', l.letterId);
-          }}
-        />
+        <LetterCarousel letters={friendLetters} emptyMessage='친구의 편지가 아직 없어요.' />
       </section>
     </div>
   );

--- a/src/pages/main/Mainpage.tsx
+++ b/src/pages/main/Mainpage.tsx
@@ -83,7 +83,7 @@ const MainPage = () => {
   }
 
   return (
-    <div className='min-h-dvh bg-white pb-22 pt-5'>
+    <div className='min-h-dvh bg-[var(--color-bg-500)] pb-22 pt-5'>
       {/* 오늘의 질문 섹션 */}
       <section className='ty-title2'>
         <QuestionCard

--- a/src/pages/main/Mainpage.tsx
+++ b/src/pages/main/Mainpage.tsx
@@ -114,10 +114,10 @@ const MainPage = () => {
       <section className='pt-2.5 pb-2.5'>
         {/* 헤더 */}
         <div className='flex items-center justify-between px-4 py-1.5'>
-          <h2 className='text-base font-semibold text-[#171717]'>공개 편지</h2>
+          <h2 className='ty-body2 text-[var(--color-text-normal)]'>공개 편지</h2>
           <button
             onClick={() => navigate('/feed/public-all')}
-            className='flex items-center gap-2 text-sm font-medium text-[#595959] hover:text-gray-700 transition-colors'
+            className='flex items-center gap-2 ty-body5 text-[var(--color-text-alternative)] hover:text-gray-700 transition-colors'
           >
             <span>전체보기</span>
             <svg width='12' height='12' viewBox='0 0 12 12' fill='none' className='rotate-180'>
@@ -140,10 +140,10 @@ const MainPage = () => {
       <section className='pt-2.5 pb-2.5'>
         {/* 헤더 */}
         <div className='flex items-center justify-between px-4 py-1.5'>
-          <h2 className='text-base font-semibold text-[#171717]'>친구 편지</h2>
+          <h2 className='ty-body2 text-[var(--color-text-normal)]'>친구 편지</h2>
           <button
             onClick={() => navigate('/feed/friend-all')}
-            className='flex items-center gap-2 text-sm font-medium text-[#595959] hover:text-gray-700 transition-colors'
+            className='flex items-center gap-2 ty-body5 text-[var(--color-text-alternative)] hover:text-gray-700 transition-colors'
           >
             <span>전체보기</span>
             <svg width='12' height='12' viewBox='0 0 12 12' fill='none' className='rotate-180'>

--- a/src/utils/anonNickname.ts
+++ b/src/utils/anonNickname.ts
@@ -1,0 +1,38 @@
+import { createRandomName } from '@/utils/nicknameGenerator';
+
+const STORAGE_KEY = 'anon_nickname_map_v1';
+
+type NickMap = Record<string, string>;
+
+const loadMap = (): NickMap => {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return raw ? (JSON.parse(raw) as NickMap) : {};
+  } catch {
+    return {};
+  }
+};
+
+const saveMap = (map: NickMap) => {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(map));
+  } catch {
+    // ignore
+  }
+};
+
+/**
+ * 동일 key(senderId)에 대해 항상 같은 익명 닉네임 반환
+ */
+export const getAnonNickname = (key: number | string): string => {
+  const k = String(key);
+  const map = loadMap();
+
+  if (map[k]) return map[k];
+
+  const name = createRandomName();
+  map[k] = name;
+  saveMap(map);
+
+  return name;
+};

--- a/src/utils/anonNickname.ts
+++ b/src/utils/anonNickname.ts
@@ -1,4 +1,4 @@
-import { createRandomName } from '@/utils/nicknameGenerator';
+import { createRandomNameWithNumber } from '@/utils/nicknameGenerator';
 
 const STORAGE_KEY = 'anon_nickname_map_v1';
 
@@ -30,7 +30,7 @@ export const getAnonNickname = (key: number | string): string => {
 
   if (map[k]) return map[k];
 
-  const name = createRandomName();
+  const name = createRandomNameWithNumber();
   map[k] = name;
   saveMap(map);
 

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -47,9 +47,7 @@ export function formatDate(
   if (Number.isNaN(date.getTime())) return fallback;
 
   const year = date.getFullYear();
-  const month = padded
-    ? String(date.getMonth() + 1).padStart(2, '0')
-    : String(date.getMonth() + 1);
+  const month = padded ? String(date.getMonth() + 1).padStart(2, '0') : String(date.getMonth() + 1);
   const day = padded ? String(date.getDate()).padStart(2, '0') : String(date.getDate());
 
   if (format === 'korean') {
@@ -57,13 +55,6 @@ export function formatDate(
   }
 
   return `${year}.${month}.${day}`;
-}
-
-/**
- * @deprecated formatDate(iso, { padded: true })를 사용하세요
- */
-export function getParseDate(iso: string): string {
-  return formatDate(iso, { padded: true });
 }
 
 // UI 파싱용 (yyyy.mm.dd hh:mm am|pm)

--- a/src/utils/nicknameGenerator.ts
+++ b/src/utils/nicknameGenerator.ts
@@ -127,16 +127,10 @@ export const createRandomName = (): string => {
  * @param {boolean} includeNumber 숫자 포함 여부 (기본값 : false)
  * @returns {string} 랜덤 닉네임 (선택적으로 숫자 포함)
  */
-export const createRandomNameWithNumber = (includeNumber: boolean = false): string => {
+export const createRandomNameWithNumber = (): string => {
   const baseName = createRandomName();
-
-  if (includeNumber) {
-    // 1부터 99 사이의 랜덤 숫자 생성
-    const randomNumber = Math.floor(Math.random() * 99) + 1;
-    return `${baseName}${randomNumber}`;
-  }
-
-  return baseName;
+  const randomNumber = Math.floor(Math.random() * 90) + 10;
+  return `${baseName}${randomNumber}`;
 };
 
 export default createRandomName;

--- a/src/utils/nicknameGenerator.ts
+++ b/src/utils/nicknameGenerator.ts
@@ -1,0 +1,142 @@
+/**
+ * 랜덤 닉네임 생성 유틸리티
+ * 형용사와 명사를 조합하여 독특한 닉네임을 생성합니다.
+ */
+
+// 형용사 목록
+const adjectives = [
+  '파란',
+  '노란',
+  '분홍',
+  '초록',
+  '보라',
+  '하얀',
+  '까만',
+  '말랑한',
+  '폭신한',
+  '동글한',
+  '납작한',
+  '조그만',
+  '커다란',
+  '귀여운',
+  '졸린',
+  '배고픈',
+  '행복한',
+  '심심한',
+  '화난',
+  '지친',
+  '느긋한',
+  '게으른',
+  '부지런한',
+  '엉뚱한',
+  '수줍은',
+  '용감한',
+  '겁많은',
+  '빠른',
+  '느린',
+  '조용한',
+  '시끄러운',
+  '차가운',
+  '따뜻한',
+  '반짝이는',
+  '흔들리는',
+  '춤추는',
+  '뛰어다니는',
+  '미끄러지는',
+  '헤엄치는',
+];
+
+// 동물 명사
+const animalNouns = [
+  '고양이',
+  '강아지',
+  '햄스터',
+  '토끼',
+  '여우',
+  '곰',
+  '판다',
+  '다람쥐',
+  '고슴도치',
+  '수달',
+  '너구리',
+  '펭귄',
+  '오리',
+  '병아리',
+  '참새',
+  '독수리',
+  '거북이',
+  '악어',
+  '도마뱀',
+  '개구리',
+  '고래',
+  '돌고래',
+  '상어',
+  '문어',
+  '해파리',
+  '나비',
+  '벌',
+  '거미',
+  '기린',
+  '코끼리',
+  '사자',
+  '호랑이',
+];
+
+// 과일 명사
+const fruitNouns = [
+  '수박',
+  '딸기',
+  '포도',
+  '사과',
+  '배',
+  '복숭아',
+  '자두',
+  '망고',
+  '바나나',
+  '파인애플',
+  '키위',
+  '귤',
+  '오렌지',
+  '레몬',
+  '체리',
+  '블루베리',
+  '라즈베리',
+  '멜론',
+  '코코넛',
+];
+
+const nouns = [...animalNouns, ...fruitNouns];
+
+/**
+ * 랜덤 닉네임을 생성합니다.
+ * @returns {string} 형용사와 명사가 조합된 랜덤 닉네임
+ */
+export const createRandomName = (): string => {
+  // 랜덤 형용사 선택
+  const randomAdjective = adjectives[Math.floor(Math.random() * adjectives.length)];
+
+  // 랜덤 명사 선택
+  const randomNoun = nouns[Math.floor(Math.random() * nouns.length)];
+
+  // 형용사와 명사 조합
+  return `${randomAdjective}${randomNoun}`;
+};
+
+/**
+ * 숫자를 포함한 랜덤 닉네임을 생성합니다.
+ * @param {boolean} includeNumber 숫자 포함 여부 (기본값 : false)
+ * @returns {string} 랜덤 닉네임 (선택적으로 숫자 포함)
+ */
+export const createRandomNameWithNumber = (includeNumber: boolean = false): string => {
+  const baseName = createRandomName();
+
+  if (includeNumber) {
+    // 1부터 99 사이의 랜덤 숫자 생성
+    const randomNumber = Math.floor(Math.random() * 99) + 1;
+    return `${baseName}${randomNumber}`;
+  }
+
+  return baseName;
+};
+
+export default createRandomName;


### PR DESCRIPTION
## 📂 관련 이슈

- closes #149 

---

## 🛠️ 작업 사항

- [x] 메인페이지, 피드 페이지 스타일 컨벤션 통일
- [x] 익명 랜덤 닉네임 발급 기능 추가

---

## 📸 관련 이미지 (스크린샷 또는 동영상)

익명 편지함 테스트 데이터가 없어 테스트가 어렵습니다. 백엔드와 소통 후 테스트 화면 추가하겠습니다.

---

## 💬 기타 설명

피드페이지에서 플로팅 버튼 > 공통 컴포넌트로 통일 가능? (유니와 소통 필요)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 익명 닉네임 생성 시스템 추가
  * 프로필 이미지 클릭으로 페이지 이동 기능 추가
  * 남은 편지 횟수를 동적으로 표시하도록 개선
  * 플로팅 버튼의 이동 목적지 업데이트

* **스타일**
  * 전체적으로 인라인 색상/타이포그래피를 CSS 변수와 클래스 기반 토큰으로 전환
  * UI 색상 토큰 통일 및 마진/간격 조정

* **버그 수정**
  * 날짜 형식 표시 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->