### PR TITLE
[Refactor] 피드페이지 공통화

### DIFF
--- a/src/components/common/FloatingButton.tsx
+++ b/src/components/common/FloatingButton.tsx
@@ -1,4 +1,5 @@
 import { useNavigate } from 'react-router-dom';
+import { Button } from './Button';
 
 interface FloatingButtonProps {
   text?: string;
@@ -39,34 +40,13 @@ export default function FloatingButton({
         pointerEvents: 'none',
       }}
     >
-      <button
+      <Button
+        size='large'
         onClick={handleClick}
-        className='w-full'
-        style={{
-          backgroundColor: 'rgb(245, 84, 76)',
-          height: '58px',
-          borderRadius: '8px',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          paddingTop: '16px',
-          paddingBottom: '16px',
-          boxShadow: '0px 0px 10px rgba(0, 0, 0, 0.1), 0px 4px 4px rgba(0, 0, 0, 0.25)',
-          pointerEvents: 'auto',
-        }}
+        className='w-full pointer-events-auto'
       >
-        <span
-          style={{
-            fontFamily: 'Pretendard',
-            fontWeight: 600,
-            fontSize: '16px',
-            lineHeight: '25.6px',
-            color: '#FFFFFF',
-          }}
-        >
-          {text}
-        </span>
-      </button>
+        {text}
+      </Button>
     </div>
   );
 }

--- a/src/components/feed/FeedPageTemplate.tsx
+++ b/src/components/feed/FeedPageTemplate.tsx
@@ -1,0 +1,126 @@
+import { useMemo } from 'react';
+import FeedHeader from '../common/headers/FeedHeader';
+import LetterPreviewCard from './LetterPreviewCard';
+import EmptyFeedCard from './EmptyFeedCard';
+import FloatingButton from '../common/FloatingButton';
+import useCountdown from '@/hooks/auth/useCountdown';
+import LoadingPage from '@/pages/system/LoadingPage';
+import ErrorPage from '@/pages/system/ErrorPage';
+import { useDailyQuestion } from '@/hooks/letters/useDailyQuestion';
+import { useCreateLike, useDeleteLike } from '@/hooks/useCreateLetterLike';
+import type { PublicFeedDetail } from '@/types/dto/feed';
+
+interface FeedLetter {
+  letterId: number;
+  title: string;
+  content: string;
+  likes: number;
+  isLiked: boolean;
+  deliveredAt: string;
+  paperId: number;
+}
+
+interface FeedPageTemplateProps {
+  title: string;
+  navigateTo: string;
+  letters: PublicFeedDetail[] | undefined;
+  isLettersLoading: boolean;
+}
+
+export default function FeedPageTemplate({
+  title,
+  navigateTo,
+  letters: rawLetters,
+  isLettersLoading,
+}: FeedPageTemplateProps) {
+  const {
+    data: questionData,
+    isLoading: isQuestionLoading,
+    isError: isQuestionError,
+  } = useDailyQuestion();
+
+  const createLike = useCreateLike();
+  const deleteLike = useDeleteLike();
+
+  const letters = useMemo<FeedLetter[]>(
+    () =>
+      rawLetters?.map((l) => ({
+        letterId: l.id,
+        title: l.title ?? '',
+        content: l.content ?? '',
+        likes: l.likes ?? 0,
+        isLiked: l.isLiked ?? false,
+        deliveredAt: l.deliveredAt ?? '',
+        paperId: l.design?.paper?.id ?? 1,
+      })) ?? [],
+    [rawLetters],
+  );
+
+  const handleToggleLike = (letterId: number, isLiked: boolean) => {
+    if (createLike.isPending || deleteLike.isPending) return;
+
+    if (isLiked) deleteLike.mutate(letterId);
+    else createLike.mutate(letterId);
+  };
+
+  const deadlineMs = useMemo(() => {
+    if (!questionData?.expiredAt) return null;
+    const t = new Date(questionData.expiredAt).getTime();
+    return Number.isNaN(t) ? null : t;
+  }, [questionData?.expiredAt]);
+
+  const { formattedTime } = useCountdown(deadlineMs ?? Date.now() + 60000);
+
+  const isLoading = isQuestionLoading || isLettersLoading;
+  const isError = isQuestionError;
+
+  if (isLoading) return <LoadingPage />;
+  if (isError) return <ErrorPage />;
+
+  const formattedQuestionText = (questionData?.content ?? '').replace(/^질문\s*#\d+:\s*/, '');
+
+  return (
+    <div className='min-h-dvh pb-24 bg-[var(--color-bg-500)]'>
+      {/* 고정 상단바 */}
+      <FeedHeader title={title} />
+
+      {/* 상단바 높이만큼 여백 */}
+      <div style={{ height: '50px' }} />
+
+      {/* 상단 질문 섹션 */}
+      <div className='flex flex-col items-start p-5 -mt-3 gap-2'>
+        <p className='text-[var(--color-primary-heavy)] ty-title2 w-[251px] whitespace-pre-line'>
+          {formattedQuestionText}
+        </p>
+        <div className='flex items-center ty-body2'>
+          <span className='text-[var(--color-primary-500)]'>{formattedTime}</span>
+          <span className='text-[var(--color-primary-heavy)] ml-1'>후에 질문이 사라져요.</span>
+        </div>
+      </div>
+
+      {/* 편지 리스트 섹션 */}
+      <section className='px-4 py-4 space-y-4'>
+        {letters.map((l) => (
+          <LetterPreviewCard
+            key={l.letterId}
+            title={l.title}
+            content={l.content}
+            paperId={l.paperId}
+            likes={l.likes}
+            isLiked={l.isLiked}
+            disabled={createLike.isPending || deleteLike.isPending}
+            isLikeLoading={
+              (createLike.isPending && createLike.variables === l.letterId) ||
+              (deleteLike.isPending && deleteLike.variables === l.letterId)
+            }
+            onToggleLike={() => handleToggleLike(l.letterId, l.isLiked)}
+          />
+        ))}
+        {letters.length <= 1 && <EmptyFeedCard />}
+      </section>
+
+      {/* 플로팅 버튼 */}
+      <FloatingButton text='나도 편지 작성하기' navigateTo={navigateTo} />
+    </div>
+  );
+}

--- a/src/components/feed/FeedPageTemplate.tsx
+++ b/src/components/feed/FeedPageTemplate.tsx
@@ -9,15 +9,12 @@ import ErrorPage from '@/pages/system/ErrorPage';
 import { useDailyQuestion } from '@/hooks/letters/useDailyQuestion';
 import { useCreateLike, useDeleteLike } from '@/hooks/useCreateLetterLike';
 import type { PublicFeedDetail } from '@/types/dto/feed';
+import type { FeedLetter } from '@/types/letter';
 
-interface FeedLetter {
-  letterId: number;
-  title: string;
+interface FeedPageLetter extends FeedLetter {
   content: string;
   likes: number;
   isLiked: boolean;
-  deliveredAt: string;
-  paperId: number;
 }
 
 interface FeedPageTemplateProps {
@@ -42,7 +39,7 @@ export default function FeedPageTemplate({
   const createLike = useCreateLike();
   const deleteLike = useDeleteLike();
 
-  const letters = useMemo<FeedLetter[]>(
+  const letters = useMemo<FeedPageLetter[]>(
     () =>
       rawLetters?.map((l) => ({
         letterId: l.id,

--- a/src/pages/feed/FriendFeedPage.tsx
+++ b/src/pages/feed/FriendFeedPage.tsx
@@ -1,115 +1,15 @@
-import { useMemo } from 'react';
-import FeedHeader from '../../components/common/headers/FeedHeader';
-import LetterPreviewCard from '../../components/feed/LetterPreviewCard';
-import EmptyFeedCard from '../../components/feed/EmptyFeedCard';
-import FloatingButton from '../../components/common/FloatingButton';
-import useCountdown from '@/hooks/auth/useCountdown';
-import LoadingPage from '../system/LoadingPage';
-import ErrorPage from '../system/ErrorPage';
-import { useDailyQuestion } from '@/hooks/letters/useDailyQuestion';
-import { useCreateLike, useDeleteLike } from '@/hooks/useCreateLetterLike';
+import FeedPageTemplate from '@/components/feed/FeedPageTemplate';
 import { useFriendPublicFeed } from '@/hooks/usePublicFeed';
 
-interface FeedLetter {
-  letterId: number; // =letterId, 좋아요 클릭시 해당 id 기반으로 요청
-  title: string;
-  content: string;
-  likes: number;
-  isLiked: boolean;
-  deliveredAt: string;
-  paperId: number;
-}
-
 export default function FriendFeedPage() {
-  const {
-    data: questionData,
-    isLoading: isQuestionLoading,
-    isError: isQuestionError,
-  } = useDailyQuestion();
-
-  const { data: publicLetters, isLoading: isLettersLoading } = useFriendPublicFeed();
-  const createLike = useCreateLike();
-  const deleteLike = useDeleteLike();
-
-  const letters = useMemo<FeedLetter[]>(
-    () =>
-      publicLetters?.map((l) => ({
-        letterId: l.id,
-        title: l.title ?? '',
-        content: l.content ?? '',
-        likes: l.likes ?? 0,
-        isLiked: l.isLiked ?? false,
-        deliveredAt: l.deliveredAt ?? '',
-        paperId: l.design?.paper?.id ?? 1,
-      })) ?? [],
-    [publicLetters],
-  );
-
-  const handleToggleLike = (letterId: number, isLiked: boolean) => {
-    if (createLike.isPending || deleteLike.isPending) return;
-
-    if (isLiked) deleteLike.mutate(letterId);
-    else createLike.mutate(letterId);
-  };
-
-  const deadlineMs = useMemo(() => {
-    if (!questionData?.expiredAt) return null;
-    const t = new Date(questionData.expiredAt).getTime();
-    return Number.isNaN(t) ? null : t;
-  }, [questionData?.expiredAt]);
-
-  const { formattedTime } = useCountdown(deadlineMs ?? Date.now() + 60000);
-
-  const isLoading = isQuestionLoading || isLettersLoading;
-  const isError = isQuestionError;
-
-  if (isLoading) return <LoadingPage />;
-  if (isError) return <ErrorPage />;
-
-  const formattedQuestionText = (questionData?.content ?? '').replace(/^질문\s*#\d+:\s*/, '');
+  const { data, isLoading } = useFriendPublicFeed();
 
   return (
-    <div className='min-h-dvh pb-24 bg-[var(--color-bg-500)]'>
-      {/* 고정 상단바 */}
-      <FeedHeader title='친구 편지' />
-
-      {/* 상단바 높이만큼 여백 */}
-      <div style={{ height: '50px' }} />
-
-      {/* 상단 질문 섹션 */}
-      <div className='flex flex-col items-start p-5 -mt-3 gap-2'>
-        <p className='text-[var(--color-primary-heavy)] ty-title2 w-[251px] whitespace-pre-line'>
-          {formattedQuestionText}
-        </p>
-        <div className='flex items-center ty-body2'>
-          <span className='text-[var(--color-primary-500)]'>{formattedTime}</span>
-          <span className='text-[var(--color-primary-heavy)] ml-1'>후에 질문이 사라져요.</span>
-        </div>
-      </div>
-
-      {/* 편지 리스트 섹션 */}
-      <section className='px-4 py-4 space-y-4'>
-        {letters.map((l) => (
-          <LetterPreviewCard
-            key={l.letterId}
-            title={l.title}
-            content={l.content}
-            paperId={l.paperId}
-            likes={l.likes}
-            isLiked={l.isLiked}
-            disabled={createLike.isPending || deleteLike.isPending}
-            isLikeLoading={
-              (createLike.isPending && createLike.variables === l.letterId) ||
-              (deleteLike.isPending && deleteLike.variables === l.letterId)
-            }
-            onToggleLike={() => handleToggleLike(l.letterId, l.isLiked)}
-          />
-        ))}
-        {letters.length <= 1 && <EmptyFeedCard />}
-      </section>
-
-      {/* 플로팅 버튼 */}
-      <FloatingButton text='나도 편지 작성하기' navigateTo='/friend/inbox' />
-    </div>
+    <FeedPageTemplate
+      title='친구 편지'
+      navigateTo='/friend/inbox'
+      letters={data}
+      isLettersLoading={isLoading}
+    />
   );
 }

--- a/src/pages/feed/PublicFeedPage.tsx
+++ b/src/pages/feed/PublicFeedPage.tsx
@@ -1,115 +1,15 @@
-import { useMemo } from 'react';
-import FeedHeader from '../../components/common/headers/FeedHeader';
-import LetterPreviewCard from '../../components/feed/LetterPreviewCard';
-import FloatingButton from '../../components/common/FloatingButton';
-import LoadingPage from '../system/LoadingPage';
-import { useDailyQuestion } from '@/hooks/letters/useDailyQuestion';
-import useCountdown from '@/hooks/auth/useCountdown';
-import ErrorPage from '../system/ErrorPage';
+import FeedPageTemplate from '@/components/feed/FeedPageTemplate';
 import { useOtherPublicFeed } from '@/hooks/usePublicFeed';
-import { useCreateLike, useDeleteLike } from '@/hooks/useCreateLetterLike';
-import EmptyFeedCard from '@/components/feed/EmptyFeedCard';
-
-interface FeedLetter {
-  letterId: number; // =letterId, 좋아요 클릭시 해당 id 기반으로 요청
-  title: string;
-  content: string;
-  likes: number;
-  isLiked: boolean;
-  deliveredAt: string;
-  paperId: number;
-}
 
 export default function FeedPage() {
-  const {
-    data: questionData,
-    isLoading: isQuestionLoading,
-    isError: isQuestionError,
-  } = useDailyQuestion();
-
-  const { data: publicLetters, isLoading: isLettersLoading } = useOtherPublicFeed();
-  const createLike = useCreateLike();
-  const deleteLike = useDeleteLike();
-
-  const letters = useMemo<FeedLetter[]>(
-    () =>
-      publicLetters?.map((l) => ({
-        letterId: l.id,
-        title: l.title ?? '',
-        content: l.content ?? '',
-        likes: l.likes ?? 0,
-        isLiked: l.isLiked ?? false,
-        deliveredAt: l.deliveredAt ?? '',
-        paperId: l.design?.paper?.id ?? 1,
-      })) ?? [],
-    [publicLetters],
-  );
-
-  const handleToggleLike = (letterId: number, isLiked: boolean) => {
-    if (createLike.isPending || deleteLike.isPending) return;
-
-    if (isLiked) deleteLike.mutate(letterId);
-    else createLike.mutate(letterId);
-  };
-
-  const deadlineMs = useMemo(() => {
-    if (!questionData?.expiredAt) return null;
-    const t = new Date(questionData.expiredAt).getTime();
-    return Number.isNaN(t) ? null : t;
-  }, [questionData?.expiredAt]);
-
-  const { formattedTime } = useCountdown(deadlineMs ?? Date.now() + 60000);
-
-  const isLoading = isQuestionLoading || isLettersLoading;
-  const isError = isQuestionError;
-
-  if (isLoading) return <LoadingPage />;
-  if (isError) return <ErrorPage />;
-
-  const formattedQuestionText = (questionData?.content ?? '').replace(/^질문\s*#\d+:\s*/, '');
+  const { data, isLoading } = useOtherPublicFeed();
 
   return (
-    <div className='min-h-dvh pb-24 bg-[var(--color-bg-500)]'>
-      {/* 고정 상단바 */}
-      <FeedHeader title='공개 편지' />
-
-      {/* 상단바 높이만큼 여백 */}
-      <div style={{ height: '50px' }} />
-
-      {/* 상단 질문 섹션 */}
-      <div className='flex flex-col items-start p-5 -mt-3 gap-2'>
-        <p className='text-[var(--color-primary-heavy)] ty-title2 w-[251px] whitespace-pre-line'>
-          {formattedQuestionText}
-        </p>
-        <div className='flex items-center ty-body2'>
-          <span className='text-[var(--color-primary-500)]'>{formattedTime}</span>
-          <span className='text-[var(--color-primary-heavy)] ml-1'>후에 질문이 사라져요.</span>
-        </div>
-      </div>
-
-      {/* 편지 리스트 섹션 */}
-      <section className='px-4 py-4 space-y-4'>
-        {letters.map((l) => (
-          <LetterPreviewCard
-            key={l.letterId}
-            title={l.title}
-            content={l.content}
-            paperId={l.paperId}
-            likes={l.likes}
-            isLiked={l.isLiked}
-            disabled={createLike.isPending || deleteLike.isPending}
-            isLikeLoading={
-              (createLike.isPending && createLike.variables === l.letterId) ||
-              (deleteLike.isPending && deleteLike.variables === l.letterId)
-            }
-            onToggleLike={() => handleToggleLike(l.letterId, l.isLiked)}
-          />
-        ))}
-        {letters.length <= 1 && <EmptyFeedCard />}
-      </section>
-
-      {/* 플로팅 버튼 */}
-      <FloatingButton text='나도 편지 작성하기' navigateTo='/letter/anon/draft' />
-    </div>
+    <FeedPageTemplate
+      title='공개 편지'
+      navigateTo='/letter/anon/draft'
+      letters={data}
+      isLettersLoading={isLoading}
+    />
   );
 }

--- a/src/pages/friend/FriendDraftPage.tsx
+++ b/src/pages/friend/FriendDraftPage.tsx
@@ -34,11 +34,11 @@ export default function FriendDraftPage() {
 
   // friendId, friendName 가져오기
   const location = useLocation();
-  const headerTitle = `${friendName ?? ''}에게 보내는 편지`;
   const { friendId, friendName } = (location.state ?? {}) as {
     friendId?: number;
     friendName?: string;
   };
+  const headerTitle = `${friendName ?? ''}에게 보내는 편지`;
 
   useEffect(() => {
     setActiveTarget('friend');

--- a/src/pages/letter/AnonDraftPage.tsx
+++ b/src/pages/letter/AnonDraftPage.tsx
@@ -104,10 +104,6 @@ const AnonDraftPage = () => {
     return () => window.clearTimeout(id);
   }, [isError, error, navigate, showToast]);
 
-  if (isLoading) {
-    return <LoadingPage />;
-  }
-
   const formattedQuestionText = (data?.content ?? '').replace(/^질문\s*#\d+:\s*/, '');
 
   if (isLoading) return <DraftSkeleton title='타인에게 보내는 편지' />;


### PR DESCRIPTION
## 📂 관련 이슈

- closes #158 

---

## 🛠️ 작업 사항

- [x] 공통되는 코드 hook으로 분리
- [x] 공통되는 타입들 정리
- [x] 피드페이지 플로팅 버튼을 공통 버튼으로 구현

---

## 📸 관련 이미지 (스크린샷 또는 동영상)

---

## 💬 기타 설명

> 💡 추가적으로 공유할 내용이나 리뷰어에게 전달할 사항이 있다면 작성해 주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 피드 페이지 템플릿 추가로 동적 일일 질문, 편지 목록, 플로팅 버튼을 포함한 통합 피드 페이지 제공
  * 좋아요 상호작용 및 카운트다운 기능 통합

* **버그 수정**
  * 초안 페이지에서 변수 초기화 순서 수정

* **UI/UX 개선**
  * 공유 Button 컴포넌트로 버튼 일관성 개선
  * 로딩 상태 UI 개선 (DraftSkeleton 적용)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->