### PR TITLE
[Refactor] API 요청 최적화 (중복 요청 방지, Debouncing, 캐싱 개선)

### DIFF
--- a/src/hooks/friend/useFriend.ts
+++ b/src/hooks/friend/useFriend.ts
@@ -46,5 +46,6 @@ export const useFriends = () =>
         throw e;
       }
     },
+    staleTime: 1000 * 60 * 2,
     retry: 0, // 일단 개발 중엔 retry 꺼서 네트워크 폭주/오해 방지 추천
   });

--- a/src/hooks/friend/useFriendThread.ts
+++ b/src/hooks/friend/useFriendThread.ts
@@ -6,6 +6,7 @@ export function useFriendThread(friendId: number) {
     queryKey: ['friend-thread', friendId],
     queryFn: () => getFriendThread(friendId),
     enabled: Number.isFinite(friendId) && friendId > 0,
+    staleTime: 1000 * 30,
     retry: false,
   });
 }

--- a/src/hooks/letters/useDailyQuestion.ts
+++ b/src/hooks/letters/useDailyQuestion.ts
@@ -10,6 +10,7 @@ export function useDailyQuestion() {
   return useQuery({
     queryKey: ['daily-question', todayKstKey],
     queryFn: () => getDailyQuestion(nowKstIso),
+    staleTime: 1000 * 60 * 5,
     retry: false,
   });
 }

--- a/src/hooks/letters/useLetterDetail.ts
+++ b/src/hooks/letters/useLetterDetail.ts
@@ -6,6 +6,7 @@ export function useLetterDetail(letterId: number) {
     queryKey: ['letter-detail', letterId],
     queryFn: () => getLetterDetail(letterId),
     enabled: Number.isFinite(letterId) && letterId > 0,
+    staleTime: 1000 * 60 * 5,
     retry: false,
   });
 }

--- a/src/hooks/letters/useLetterDetails.ts
+++ b/src/hooks/letters/useLetterDetails.ts
@@ -20,6 +20,7 @@ export function useLetterDetails(letterIds: number[]) {
       queryKey: ['letter-detail', letterId] as const,
       queryFn: () => getLetterDetail(letterId),
       enabled: uniqueIds.length > 0, // id별 enabled 대신 한번에 켜도 됨
+      staleTime: 1000 * 60 * 5,
       retry: false,
     })),
   });

--- a/src/hooks/letters/useLetterStyleOptions.ts
+++ b/src/hooks/letters/useLetterStyleOptions.ts
@@ -9,5 +9,6 @@ export function useLetterStyleOptions() {
   return useQuery({
     queryKey: letterStylekeys.options,
     queryFn: getLetterStyleOptions,
+    staleTime: 1000 * 60 * 30,
   });
 }

--- a/src/hooks/mails/useAnonMailbox.ts
+++ b/src/hooks/mails/useAnonMailbox.ts
@@ -5,6 +5,7 @@ export function useAnonMailbox() {
   return useQuery({
     queryKey: ['anon-mailbox'],
     queryFn: getAnonMailbox,
+    staleTime: 1000 * 60,
     retry: false,
   });
 }

--- a/src/hooks/mails/useAnonThread.ts
+++ b/src/hooks/mails/useAnonThread.ts
@@ -6,6 +6,7 @@ export function useAnonThread(sessionId: number) {
     queryKey: ['anon-thread', sessionId],
     queryFn: () => getAnonThread(sessionId),
     enabled: Number.isFinite(sessionId) && sessionId > 0,
+    staleTime: 1000 * 30,
     retry: false,
   });
 }

--- a/src/hooks/mails/useSelfMailbox.ts
+++ b/src/hooks/mails/useSelfMailbox.ts
@@ -5,6 +5,7 @@ export function useSelfMailbox() {
   return useQuery({
     queryKey: ['self-mailbox'],
     queryFn: getSelfMailbox,
+    staleTime: 1000 * 60,
     retry: false,
   });
 }

--- a/src/hooks/onboarding/useMyConsents.ts
+++ b/src/hooks/onboarding/useMyConsents.ts
@@ -24,6 +24,7 @@ export function useMyConsents(enabled: boolean = true) {
       throw res.error;
     },
     enabled,
+    staleTime: 1000 * 60 * 5,
     retry: 0,
   });
 }

--- a/src/hooks/onboarding/useMyInterests.ts
+++ b/src/hooks/onboarding/useMyInterests.ts
@@ -10,6 +10,7 @@ export const useMyInterests = (enabled: boolean) =>
     queryKey: onboardingKeys.myInterests,
     queryFn: onboardingApi.getMyInterests,
     enabled,
+    staleTime: 1000 * 60 * 5,
     select: (res) => {
       if (res.resultType === 'SUCCESS') return res.success.items;
       throw res.error;

--- a/src/hooks/onboarding/useMyNotificationSettings.ts
+++ b/src/hooks/onboarding/useMyNotificationSettings.ts
@@ -20,6 +20,7 @@ export function useMyNotificationSettings(enabled: boolean = true) {
     queryKey: onboardingKeys.notificationSettings,
     queryFn: () => getMyNotificationSettings(),
     enabled,
+    staleTime: 1000 * 60 * 5,
     retry: 0,
     select: (res) => {
       if (res.resultType === 'SUCCESS') return res.success;

--- a/src/hooks/useCreateLetterLike.ts
+++ b/src/hooks/useCreateLetterLike.ts
@@ -1,24 +1,69 @@
 import { deleteLetterLike, postLetterLike } from '@/api/like';
+import type { PublicFeedDetail } from '@/types/dto/feed';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
-export function useCreateLike() {
+const FEED_KEYS = ['other-public-feed', 'friend-public-feed'] as const;
+
+type LikeContext = {
+  snapshots: [readonly unknown[], PublicFeedDetail[] | undefined][];
+};
+
+function useOptimisticLike(
+  mutationFn: (letterId: number) => Promise<unknown>,
+  applyUpdate: (letter: PublicFeedDetail, letterId: number) => PublicFeedDetail,
+) {
   const qc = useQueryClient();
-  return useMutation({
-    mutationFn: (letterId: number) => postLetterLike(letterId),
-    onSuccess: () => {
-      qc.invalidateQueries({ queryKey: ['other-public-feed'] });
-      qc.invalidateQueries({ queryKey: ['friend-public-feed'] });
+
+  return useMutation<unknown, unknown, number, LikeContext>({
+    mutationFn,
+    onMutate: async (letterId) => {
+      const snapshots: LikeContext['snapshots'] = [];
+
+      for (const key of FEED_KEYS) {
+        await qc.cancelQueries({ queryKey: [key] });
+
+        const queries = qc.getQueriesData<PublicFeedDetail[]>({ queryKey: [key] });
+
+        for (const [queryKey, data] of queries) {
+          snapshots.push([queryKey, data]);
+
+          if (data) {
+            qc.setQueryData<PublicFeedDetail[]>(
+              queryKey,
+              data.map((l) => (l.id === letterId ? applyUpdate(l, letterId) : l)),
+            );
+          }
+        }
+      }
+
+      return { snapshots };
+    },
+    onError: (_err, _letterId, ctx) => {
+      if (!ctx) return;
+      for (const [queryKey, data] of ctx.snapshots) {
+        qc.setQueryData(queryKey, data);
+      }
+    },
+    onSettled: () => {
+      for (const key of FEED_KEYS) {
+        qc.invalidateQueries({ queryKey: [key] });
+      }
     },
   });
 }
 
+export function useCreateLike() {
+  return useOptimisticLike(postLetterLike, (letter) => ({
+    ...letter,
+    isLiked: true,
+    likes: letter.likes + 1,
+  }));
+}
+
 export function useDeleteLike() {
-  const qc = useQueryClient();
-  return useMutation({
-    mutationFn: (letterId: number) => deleteLetterLike(letterId),
-    onSuccess: () => {
-      qc.invalidateQueries({ queryKey: ['other-public-feed'] });
-      qc.invalidateQueries({ queryKey: ['friend-public-feed'] });
-    },
-  });
+  return useOptimisticLike(deleteLetterLike, (letter) => ({
+    ...letter,
+    isLiked: false,
+    likes: Math.max(0, letter.likes - 1),
+  }));
 }

--- a/src/hooks/useDebouncedValue.ts
+++ b/src/hooks/useDebouncedValue.ts
@@ -1,0 +1,12 @@
+import { useEffect, useState } from 'react';
+
+export function useDebouncedValue<T>(value: T, delay = 300): T {
+  const [debounced, setDebounced] = useState(value);
+
+  useEffect(() => {
+    const id = setTimeout(() => setDebounced(value), delay);
+    return () => clearTimeout(id);
+  }, [value, delay]);
+
+  return debounced;
+}

--- a/src/hooks/useDebouncedValue.ts
+++ b/src/hooks/useDebouncedValue.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 
 export function useDebouncedValue<T>(value: T, delay = 300): T {
-  const [debounced, setDebounced] = useState(value);
+  const [debounced, setDebounced] = useState(() => value);
 
   useEffect(() => {
     const id = setTimeout(() => setDebounced(value), delay);

--- a/src/hooks/useHomeSummary.ts
+++ b/src/hooks/useHomeSummary.ts
@@ -11,6 +11,7 @@ export function useHomeSummary() {
   const query = useQuery({
     queryKey: ['home-summary', todayKstKey],
     queryFn: () => getHomeSummary(nowKstIso),
+    staleTime: 1000 * 60 * 2,
     retry: false,
     select: (res) => {
       if (res.resultType !== 'SUCCESS' || !res.success) {

--- a/src/hooks/usePublicFeed.ts
+++ b/src/hooks/usePublicFeed.ts
@@ -8,6 +8,7 @@ export function useOtherPublicFeed() {
   return useQuery({
     queryKey: ['other-public-feed', todayKey],
     queryFn: getOtherPublicFeed,
+    staleTime: 1000 * 60 * 2,
     retry: false,
   });
 }
@@ -18,6 +19,7 @@ export function useFriendPublicFeed() {
   return useQuery({
     queryKey: ['friend-public-feed', todayKey],
     queryFn: getFriendPublicFeed,
+    staleTime: 1000 * 60 * 2,
     retry: false,
   });
 }

--- a/src/hooks/usePublicLetters.ts
+++ b/src/hooks/usePublicLetters.ts
@@ -8,6 +8,7 @@ export function useOtherPublicLetters() {
   return useQuery({
     queryKey: ['other-public-letters', todayKey],
     queryFn: getOtherPublicLetters,
+    staleTime: 1000 * 60 * 2,
     retry: false,
   });
 }
@@ -18,6 +19,7 @@ export function useFriendPublicLetters() {
   return useQuery({
     queryKey: ['friend-public-letters', todayKey],
     queryFn: getFriendPublicLetters,
+    staleTime: 1000 * 60 * 2,
     retry: false,
   });
 }

--- a/src/hooks/weeklyReport/useLettersByKeyword.ts
+++ b/src/hooks/weeklyReport/useLettersByKeyword.ts
@@ -41,6 +41,7 @@ export function useLettersByKeyword(aiKeyword: string) {
       return { raw: res, list };
     },
     enabled: Boolean(aiKeyword),
+    staleTime: 1000 * 60,
     retry: 0,
   });
 }

--- a/src/pages/friend/FriendInboxPage.tsx
+++ b/src/pages/friend/FriendInboxPage.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from 'react';
+import { useDebouncedValue } from '@/hooks/useDebouncedValue';
 import { useNavigate } from 'react-router-dom';
 
 import TitleHeader from '@/components/common/headers/TitleHeader';
@@ -27,6 +28,7 @@ type SortOrder = 'latest' | 'oldest';
 export default function FriendInboxPage() {
   const navigate = useNavigate();
   const [keyword, setKeyword] = useState('');
+  const debouncedKeyword = useDebouncedValue(keyword, 300);
   const [sortOrder, setSortOrder] = useState<SortOrder>('latest'); // 최신순 기본
 
   const { data: friends = [], isLoading } = useFriends();
@@ -61,14 +63,14 @@ export default function FriendInboxPage() {
   };
 
   const filtered = useMemo(() => {
-    const k = keyword.trim().toLowerCase();
+    const k = debouncedKeyword.trim().toLowerCase();
 
     const result = !k ? items : items.filter((x) => (x.name ?? '').toLowerCase().includes(k));
 
     return [...result].sort((a, b) =>
       sortOrder === 'latest' ? b.lastAtMs - a.lastAtMs : a.lastAtMs - b.lastAtMs,
     );
-  }, [items, keyword, sortOrder]);
+  }, [items, debouncedKeyword, sortOrder]);
 
   const isEmptyFriends = !isLoading && items.length === 0;
   const isEmptySearch = !isLoading && items.length > 0 && filtered.length === 0;

--- a/src/pages/letter/AnonDraftPage.tsx
+++ b/src/pages/letter/AnonDraftPage.tsx
@@ -11,7 +11,6 @@ import { useEffect, useMemo, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import DraftSkeleton from '@/components/skeleton/DraftSkeleton';
 import { validateLetter } from '@/utils/validateLetter';
-import LoadingPage from '../system/LoadingPage';
 
 const AnonDraftPage = () => {
   const { data, isLoading, isError, error } = useDailyQuestion();

--- a/src/pages/letter/LetterInboxOtherPage.tsx
+++ b/src/pages/letter/LetterInboxOtherPage.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from 'react';
+import { useDebouncedValue } from '@/hooks/useDebouncedValue';
 import { useNavigate } from 'react-router-dom';
 
 import TitleHeader from '@/components/common/headers/TitleHeader';
@@ -38,6 +39,7 @@ export default function LetterInboxOtherPage() {
 
   const [tab, setTab] = useState<LetterInboxTabKey>('other');
   const [keyword, setKeyword] = useState('');
+  const debouncedKeyword = useDebouncedValue(keyword, 300);
   const [sortOrder, setSortOrder] = useState<SortOrder>('latest');
 
   // 서버 응답을 화면 아이템으로 변환
@@ -65,7 +67,7 @@ export default function LetterInboxOtherPage() {
   }, [data]);
 
   const filtered = useMemo(() => {
-    const k = keyword.trim();
+    const k = debouncedKeyword.trim();
 
     const result = !k
       ? items
@@ -76,7 +78,7 @@ export default function LetterInboxOtherPage() {
         ? b.receivedAtMs - a.receivedAtMs
         : a.receivedAtMs - b.receivedAtMs;
     });
-  }, [items, keyword, sortOrder]);
+  }, [items, debouncedKeyword, sortOrder]);
 
   const handleTabChange = (next: LetterInboxTabKey) => {
     setTab(next);

--- a/src/pages/letter/LetterInboxSelfPage.tsx
+++ b/src/pages/letter/LetterInboxSelfPage.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from 'react';
+import { useDebouncedValue } from '@/hooks/useDebouncedValue';
 import { useNavigate } from 'react-router-dom';
 
 import TitleHeader from '@/components/common/headers/TitleHeader';
@@ -31,6 +32,7 @@ export default function LetterInboxSelfPage() {
 
   const [tab, setTab] = useState<LetterInboxTabKey>('received');
   const [keyword, setKeyword] = useState('');
+  const debouncedKeyword = useDebouncedValue(keyword, 300);
   const [sortOrder, setSortOrder] = useState<SortOrder>('latest');
 
   // 서버 응답 -> 화면 아이템으로 변환 (isUnread 제외)
@@ -50,7 +52,7 @@ export default function LetterInboxSelfPage() {
   }, [data]);
 
   const filtered = useMemo(() => {
-    const k = keyword.trim();
+    const k = debouncedKeyword.trim();
 
     const result = !k ? items : items.filter((x) => x.title.includes(k) || x.question.includes(k));
 
@@ -59,7 +61,7 @@ export default function LetterInboxSelfPage() {
         ? b.receivedAtMs - a.receivedAtMs
         : a.receivedAtMs - b.receivedAtMs;
     });
-  }, [items, keyword, sortOrder]);
+  }, [items, debouncedKeyword, sortOrder]);
 
   const handleTabChange = (next: LetterInboxTabKey) => {
     setTab(next);


### PR DESCRIPTION
## 📂 관련 이슈

- closes #174 

---

## 🛠️ 작업 사항

- [x] 검색 Debouncing
- [x] 좋아요 optimistic update
- [x] 데이터 변경 빈도에 따라 useQuery staleTime 설정

---

## 📸 관련 이미지 (스크린샷 또는 동영상)

---

## 💬 기타 설명

> 💡 추가적으로 공유할 내용이나 리뷰어에게 전달할 사항이 있다면 작성해 주세요.

마운트마다 불필요한 refetch를 방지하기 위해 변경 빈도별로 staleTime 적용 
(30분: 스타일 옵션 / 5분: 편지 상세·설정 /2분: 피드·친구 목록 / 1분: 편지함 / 30초: 대화 스레드)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 검색 입력 시 응답성이 향상된 지연 검색(debounced search) 추가
  * 좋아요(Like)에 즉시 반영되는 낙관적 업데이트 도입
  * 재사용 가능한 값 지연 처리 유틸리티 추가

* **성능 개선**
  * 여러 데이터 조회의 캐시 지속시간 조정으로 불필요한 재요청 감소

* **코드 정리**
  * 미사용 import 제거
<!-- end of auto-generated comment: release notes by coderabbit.ai -->