### PR TITLE
[Feat] 친구 페이지 API 최적화 및 프로필 데이터 바인딩 

### DIFF
--- a/src/components/common/QuestionCard.tsx
+++ b/src/components/common/QuestionCard.tsx
@@ -1,6 +1,8 @@
 import { ROUTES } from '@/routes/paths';
 import { useNavigate } from 'react-router-dom';
 
+import Soksakletter from '@/assets/icons/Soksakletter.svg?react';
+
 interface QuestionCardProps {
   question: string;
   timeLeft: string;
@@ -28,24 +30,25 @@ export default function QuestionCard({ question, timeLeft, profileImageUrl }: Qu
         </div>
 
         {/* 프로필 이미지 */}
-        {profileImageUrl && (
-          <div
-            onClick={handleMypage}
-            className='flex-shrink-0 rounded-full overflow-hidden cursor-pointer'
-            style={{
-              width: '47px',
-              height: '48px',
-              border: '0.5px solid #E2E2E2',
-            }}
-          >
-            <img
-              src={profileImageUrl}
-              alt='프로필'
-              className='w-full h-full object-cover cursor-pointer'
-              onClick={handleMypage}
-            />
-          </div>
-        )}
+        <div
+          onClick={handleMypage}
+          className={`flex-shrink-0 rounded-full overflow-hidden cursor-pointer ${
+            !profileImageUrl ? 'bg-[var(--color-primary-100)]' : ''
+          }`}
+          style={{
+            width: '47px',
+            height: '48px',
+            border: '0.5px solid #E2E2E2',
+          }}
+        >
+          {profileImageUrl ? (
+            <img src={profileImageUrl} alt='프로필' className='w-full h-full object-cover' />
+          ) : (
+            <div className='w-full h-full flex items-center justify-center'>
+              <Soksakletter className='w-6 h-6' />
+            </div>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/src/pages/friend/FriendInboxPage.tsx
+++ b/src/pages/friend/FriendInboxPage.tsx
@@ -14,6 +14,7 @@ import InboxSkeleton from '@/components/skeleton/InboxSkeleton';
 type FriendInboxItem = {
   id: number;
   friendUserId: number;
+  profileImageUrl: string | null;
   name: string;
   exchangeCount: number;
   lastDate: string; // '2026.1.3'
@@ -31,6 +32,9 @@ export default function FriendInboxPage() {
   const debouncedKeyword = useDebouncedValue(keyword, 300);
   const [sortOrder, setSortOrder] = useState<SortOrder>('latest'); // 최신순 기본
 
+  // 컴포넌트가 처음 생성될 때 한 번만 현재 시간을 저장 (캐시 버스터 고정)
+  const cacheBuster = useMemo(() => Date.now(), []);
+
   const { data: friends = [], isLoading } = useFriends();
 
   const items = useMemo<FriendInboxItem[]>(
@@ -42,6 +46,7 @@ export default function FriendInboxPage() {
         return {
           id: f.id,
           friendUserId: f.friendUserId,
+          profileImageUrl: f.profileImageUrl,
           name: (f.nickname ?? '').trim(),
           exchangeCount: f.letterCount,
 
@@ -128,8 +133,19 @@ export default function FriendInboxPage() {
                 {/* 상단: 프로필 + 봉투 */}
                 <div className='flex items-center justify-between gap-3'>
                   <div className='flex flex-col items-start gap-3 mt-2 ml-1'>
-                    {/* TODO : 프로필 사진 불러오기 */}
-                    <div className='h-10 w-10 rounded-full bg-[#EDEDED]' />
+                    {/* 프로필 이미지 원형 컨테이너 */}
+                    <div className='h-12 w-12 shrink-0 rounded-full bg-[var(--color-primary-100)] overflow-hidden flex items-center justify-center'>
+                      {f.profileImageUrl ? (
+                        <img
+                          src={`${f.profileImageUrl}?t=${cacheBuster}`}
+                          alt='프로필'
+                          className='w-full h-full object-cover '
+                        />
+                      ) : (
+                        /* 이미지가 없을 때 보여줄 빈 화면 */
+                        <div className='w-full h-full bg-[var(--color-primary-100)]' />
+                      )}
+                    </div>
                     <div>
                       <p className='ty-body2'>{f.name}</p>
                       <p className='mt-1 ty-detailMedium'>편지를 나눈 횟수 {f.exchangeCount}회</p>

--- a/src/pages/friend/FriendReplyPage.tsx
+++ b/src/pages/friend/FriendReplyPage.tsx
@@ -11,6 +11,7 @@ import { DEFAULT_FONT_ID, FONT_ASSET_MAP } from '@/constants/fontAssets';
 import { DEFAULT_PAPER_ID, PAPER_ASSET_MAP } from '@/constants/paperAssets';
 import { useLetterStore } from '@/stores/letterStore';
 import { getParseSentAt } from '@/utils/date';
+import { useThreadFlowStore } from '@/stores/letterContextStore';
 
 type ReplyData = {
   title: string;
@@ -35,6 +36,8 @@ export default function FriendReplyPage() {
   const { letterId: letterIdParam, friendId: friendIdParam } = useParams();
   const letterId = letterIdParam ? Number(letterIdParam) : 0;
   const friendId = friendIdParam ? Number(friendIdParam) : 0;
+  //스토어에 저장
+  const { setFlow } = useThreadFlowStore();
 
   const { data, isLoading, isError, refetch } = useLetterDetail(letterId);
   const { setActiveTarget, patchDraft } = useLetterStore();
@@ -76,6 +79,13 @@ export default function FriendReplyPage() {
     return <NotFoundPage />;
 
   const handleReport = () => {
+    // 스토어에 신고 대상 정보 저장
+    setFlow({
+      target: 'friend',
+      friendName: friendName, // 현재 페이지에서 쓰고 있는 친구 이름
+      senderId: friendId,
+    });
+
     navigate('/letter/report', {
       state: {
         letterId,

--- a/src/pages/letter/LetterReportPage.tsx
+++ b/src/pages/letter/LetterReportPage.tsx
@@ -12,7 +12,6 @@ import { useThreadFlowStore } from '@/stores/letterContextStore';
 
 import { useGlobalToast } from '@/components/toast/ToastProvider';
 import { useMyProfile } from '@/hooks/useMyProfile';
-import { useLetterStore } from '@/stores/letterStore';
 
 const LetterReportPage = () => {
   const navigate = useNavigate();
@@ -22,14 +21,13 @@ const LetterReportPage = () => {
   // state에서 letterId와 stamp 꺼내기
   const letterId = location.state?.letterId as number | undefined;
   const stampUrl = location.state?.stampUrl;
-  const activeTarget = useLetterStore((s) => s.activeTarget);
   const contextTarget = useThreadFlowStore((s) => s.target);
 
   const friendName = useThreadFlowStore((s) => s.friendName ?? '친구');
   const senderName = useThreadFlowStore((s) => s.senderName ?? '익명');
 
-  // 최종 타겟 결정 (컨텍스트에 있으면 쓰고, 없으면 작성 스토어 참고)
-  const finalTarget = contextTarget || activeTarget;
+  // 최종 타겟 결정 (컨텍스트에 있으면 참고)
+  const finalTarget = contextTarget;
 
   // 최종 닉네임 결정
   const displayNickname = finalTarget === 'friend' ? friendName : senderName;

--- a/src/pages/letter/LetterReportPage.tsx
+++ b/src/pages/letter/LetterReportPage.tsx
@@ -12,6 +12,7 @@ import { useThreadFlowStore } from '@/stores/letterContextStore';
 
 import { useGlobalToast } from '@/components/toast/ToastProvider';
 import { useMyProfile } from '@/hooks/useMyProfile';
+import { useLetterStore } from '@/stores/letterStore';
 
 const LetterReportPage = () => {
   const navigate = useNavigate();
@@ -21,7 +22,17 @@ const LetterReportPage = () => {
   // state에서 letterId와 stamp 꺼내기
   const letterId = location.state?.letterId as number | undefined;
   const stampUrl = location.state?.stampUrl;
+  const activeTarget = useLetterStore((s) => s.activeTarget);
+  const contextTarget = useThreadFlowStore((s) => s.target);
+
+  const friendName = useThreadFlowStore((s) => s.friendName ?? '친구');
   const senderName = useThreadFlowStore((s) => s.senderName ?? '익명');
+
+  // 최종 타겟 결정 (컨텍스트에 있으면 쓰고, 없으면 작성 스토어 참고)
+  const finalTarget = contextTarget || activeTarget;
+
+  // 최종 닉네임 결정
+  const displayNickname = finalTarget === 'friend' ? friendName : senderName;
 
   // store에서 senderId 가져오기 (fallback용)
   const senderIdFromStore = useThreadFlowStore((s) => s.senderId);
@@ -198,10 +209,9 @@ const LetterReportPage = () => {
                 )}
               </div>
             </div>
-            <span className='ty-body2'>{senderName}님</span>
+            <span className='ty-body2'>{displayNickname}님</span>
           </div>
         </div>
-
         <div className='px-4'>
           {/* 안내 문구 */}
           <div className='mb-6'>

--- a/src/pages/main/Mainpage.tsx
+++ b/src/pages/main/Mainpage.tsx
@@ -93,7 +93,7 @@ const MainPage = () => {
           profileImageUrl={
             homeSummary?.user?.profileImageUrl
               ? `${homeSummary.user.profileImageUrl}?t=${profileImageCacheBuster}`
-              : 'https://placehold.co/47x48'
+              : undefined
           }
         />
       </section>

--- a/src/types/dto/friend.ts
+++ b/src/types/dto/friend.ts
@@ -17,6 +17,7 @@ export type FriendItem = {
   id: number;
   friendUserId: number;
   nickname: string;
+  profileImageUrl: string | null;
   letterCount: number;
   recentLetter: RecentLetter | null;
 };


### PR DESCRIPTION
## 📂 관련 이슈

- closes #181 

---친구 페이지 친구 목록에서 친구 프로필url 추가 연동 및 신고 페이지 친구일 때 친구 닉네임 데이터 바인딩

## 🛠️ 작업 사항

- [x] 친구 페이지 친구 목록 프로필url api 연동
- [x] 신고 페이지 친구 닉네임,타켓 등  store에 저장 로직 추가
- [x] 신고 페이지 타켓 별 상대 닉네임 뿌리는 로직 추가
- [x] 친구 페이지 프로필 이미지 없을 때 기본 이미지 변동
- [x] 메인 페이지 프로필 이미지 없을 때 기본 이미지 변동
---

## 📸 관련 이미지 (스크린샷 또는 동영상)

---
<img width="198" height="517" alt="스크린샷 2026-02-12 오후 1 04 20" src="https://github.com/user-attachments/assets/d51f0e64-fffa-4b81-a9c8-2376379ccea3" />
<img width="200" height="519" alt="스크린샷 2026-02-12 오후 1 04 50" src="https://github.com/user-attachments/assets/0c989714-522c-44a0-81cb-8412be4431e3" />




## 💬 기타 설명

> 💡 추가적으로 공유할 내용이나 리뷰어에게 전달할 사항이 있다면 작성해 주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 프로필 이미지 표시 개선: 이미지가 없을 때 플레이스홀더 아이콘 추가.
  * 프로필 이미지 캐시 버스팅으로 최신 이미지 표시 보장.
  * 신고 기능 개선: 신고 페이지에서 올바른 사용자 정보 표시.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->