### PR TITLE
[Feat] 조회 목록에 클라이언트 사이드 무한 스크롤 추가

### DIFF
--- a/src/components/common/headers/FeedHeader.tsx
+++ b/src/components/common/headers/FeedHeader.tsx
@@ -15,7 +15,7 @@ export default function FeedHeader({ title = '공개 편지' }: FeedHeaderProps)
     <header
       className='fixed top-0 left-1/2 z-50 flex items-center justify-center px-4 py-3'
       style={{
-        backgroundColor: 'bg-[var(--color-bg-500)]',
+        backgroundColor: 'var(--color-bg-500)',
         height: '50px',
         width: '375px',
         transform: 'translateX(-50%)',

--- a/src/components/feed/FeedPageTemplate.tsx
+++ b/src/components/feed/FeedPageTemplate.tsx
@@ -1,15 +1,19 @@
-import { useMemo } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import FeedHeader from '../common/headers/FeedHeader';
 import LetterPreviewCard from './LetterPreviewCard';
 import EmptyFeedCard from './EmptyFeedCard';
 import FloatingButton from '../common/FloatingButton';
+import { LoadingDots } from '@/components/LoadingDots';
 import useCountdown from '@/hooks/auth/useCountdown';
+import { useIntersectionObserver } from '@/hooks/useIntersectionObserver';
 import LoadingPage from '@/pages/system/LoadingPage';
 import ErrorPage from '@/pages/system/ErrorPage';
 import { useDailyQuestion } from '@/hooks/letters/useDailyQuestion';
 import { useCreateLike, useDeleteLike } from '@/hooks/useCreateLetterLike';
 import type { PublicFeedDetail } from '@/types/dto/feed';
 import type { FeedLetter } from '@/types/letter';
+
+const PAGE_SIZE = 10;
 
 interface FeedPageLetter extends FeedLetter {
   content: string;
@@ -51,6 +55,23 @@ export default function FeedPageTemplate({
         paperId: l.design?.paper?.id ?? 1,
       })) ?? [],
     [rawLetters],
+  );
+
+  const [displayCount, setDisplayCount] = useState(PAGE_SIZE);
+  const hasMore = displayCount < letters.length;
+
+  const handleLoadMore = useCallback(() => {
+    setDisplayCount((prev) => Math.min(prev + PAGE_SIZE, letters.length));
+  }, [letters.length]);
+
+  const sentinelRef = useIntersectionObserver({
+    onIntersect: handleLoadMore,
+    enabled: hasMore,
+  });
+
+  const visibleLetters = useMemo(
+    () => letters.slice(0, displayCount),
+    [letters, displayCount],
   );
 
   const handleToggleLike = (letterId: number, isLiked: boolean) => {
@@ -97,7 +118,7 @@ export default function FeedPageTemplate({
 
       {/* 편지 리스트 섹션 */}
       <section className='px-4 py-4 space-y-4'>
-        {letters.map((l) => (
+        {visibleLetters.map((l) => (
           <LetterPreviewCard
             key={l.letterId}
             title={l.title}
@@ -113,7 +134,14 @@ export default function FeedPageTemplate({
             onToggleLike={() => handleToggleLike(l.letterId, l.isLiked)}
           />
         ))}
-        {letters.length <= 1 && <EmptyFeedCard />}
+        {!hasMore && letters.length <= 1 && <EmptyFeedCard />}
+
+        {hasMore && (
+          <div className='flex justify-center py-4'>
+            <LoadingDots fillIntervalMs={350} />
+          </div>
+        )}
+        <div ref={sentinelRef} className='h-1' />
       </section>
 
       {/* 플로팅 버튼 */}

--- a/src/components/feed/FeedPageTemplate.tsx
+++ b/src/components/feed/FeedPageTemplate.tsx
@@ -67,12 +67,10 @@ export default function FeedPageTemplate({
   const sentinelRef = useIntersectionObserver({
     onIntersect: handleLoadMore,
     enabled: hasMore,
+    resetKey: displayCount,
   });
 
-  const visibleLetters = useMemo(
-    () => letters.slice(0, displayCount),
-    [letters, displayCount],
-  );
+  const visibleLetters = useMemo(() => letters.slice(0, displayCount), [letters, displayCount]);
 
   const handleToggleLike = (letterId: number, isLiked: boolean) => {
     if (createLike.isPending || deleteLike.isPending) return;
@@ -101,7 +99,6 @@ export default function FeedPageTemplate({
     <div className='min-h-dvh pb-24 bg-[var(--color-bg-500)]'>
       {/* 고정 상단바 */}
       <FeedHeader title={title} />
-
       {/* 상단바 높이만큼 여백 */}
       <div style={{ height: '50px' }} />
 

--- a/src/components/feed/FeedPageTemplate.tsx
+++ b/src/components/feed/FeedPageTemplate.tsx
@@ -114,7 +114,12 @@ export default function FeedPageTemplate({
       </div>
 
       {/* 편지 리스트 섹션 */}
-      <section className='px-4 py-4 space-y-4'>
+      <section
+        role='feed'
+        aria-label='공개 편지 목록'
+        aria-busy={hasMore}
+        className='px-4 py-4 space-y-4'
+      >
         {visibleLetters.map((l) => (
           <LetterPreviewCard
             key={l.letterId}
@@ -134,11 +139,11 @@ export default function FeedPageTemplate({
         {!hasMore && letters.length <= 1 && <EmptyFeedCard />}
 
         {hasMore && (
-          <div className='flex justify-center py-4'>
+          <div role='status' aria-label='편지 불러오는 중' className='flex justify-center py-4'>
             <LoadingDots fillIntervalMs={350} />
           </div>
         )}
-        <div ref={sentinelRef} className='h-1' />
+        <div ref={sentinelRef} aria-hidden='true' className='h-1' />
       </section>
 
       {/* 플로팅 버튼 */}

--- a/src/hooks/useIntersectionObserver.ts
+++ b/src/hooks/useIntersectionObserver.ts
@@ -1,0 +1,36 @@
+import { useEffect, useRef } from 'react';
+
+interface UseIntersectionObserverOptions {
+  onIntersect: () => void;
+  enabled?: boolean;
+  rootMargin?: string;
+  threshold?: number;
+}
+
+export function useIntersectionObserver({
+  onIntersect,
+  enabled = true,
+  rootMargin = '0px 0px 200px 0px',
+  threshold = 0,
+}: UseIntersectionObserverOptions) {
+  const targetRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const el = targetRef.current;
+    if (!el || !enabled) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          onIntersect();
+        }
+      },
+      { rootMargin, threshold },
+    );
+
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [onIntersect, enabled, rootMargin, threshold]);
+
+  return targetRef;
+}

--- a/src/hooks/useIntersectionObserver.ts
+++ b/src/hooks/useIntersectionObserver.ts
@@ -5,6 +5,8 @@ interface UseIntersectionObserverOptions {
   enabled?: boolean;
   rootMargin?: string;
   threshold?: number;
+  /** 값이 바뀌면 옵저버를 재등록하여 재감지 */
+  resetKey?: unknown;
 }
 
 export function useIntersectionObserver({
@@ -12,8 +14,11 @@ export function useIntersectionObserver({
   enabled = true,
   rootMargin = '0px 0px 200px 0px',
   threshold = 0,
+  resetKey,
 }: UseIntersectionObserverOptions) {
   const targetRef = useRef<HTMLDivElement | null>(null);
+  const onIntersectRef = useRef(onIntersect);
+  onIntersectRef.current = onIntersect;
 
   useEffect(() => {
     const el = targetRef.current;
@@ -22,7 +27,7 @@ export function useIntersectionObserver({
     const observer = new IntersectionObserver(
       ([entry]) => {
         if (entry.isIntersecting) {
-          onIntersect();
+          onIntersectRef.current();
         }
       },
       { rootMargin, threshold },
@@ -30,7 +35,7 @@ export function useIntersectionObserver({
 
     observer.observe(el);
     return () => observer.disconnect();
-  }, [onIntersect, enabled, rootMargin, threshold]);
+  }, [enabled, rootMargin, threshold, resetKey]);
 
   return targetRef;
 }

--- a/src/pages/letter/LetterInboxOtherPage.tsx
+++ b/src/pages/letter/LetterInboxOtherPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useDebouncedValue } from '@/hooks/useDebouncedValue';
 import { useNavigate } from 'react-router-dom';
 import { useIntersectionObserver } from '@/hooks/useIntersectionObserver';
@@ -106,6 +106,10 @@ export default function LetterInboxOtherPage() {
 
   const PAGE_SIZE = 10;
   const [displayCount, setDisplayCount] = useState(PAGE_SIZE);
+
+  useEffect(() => {
+    setDisplayCount(PAGE_SIZE);
+  }, [debouncedKeyword, sortOrder]);
   const hasMore = displayCount < filtered.length;
 
   const handleLoadMore = useCallback(() => {

--- a/src/pages/letter/LetterInboxOtherPage.tsx
+++ b/src/pages/letter/LetterInboxOtherPage.tsx
@@ -146,6 +146,7 @@ export default function LetterInboxOtherPage() {
                 value={keyword}
                 onChange={(e) => setKeyword(e.target.value)}
                 placeholder='키워드를 검색해보세요'
+                aria-label='편지 검색'
                 className='w-full bg-transparent ty-body5 outline-none placeholder:text-[var(--color-text-assistive)]'
               />
             </div>
@@ -153,12 +154,12 @@ export default function LetterInboxOtherPage() {
               type='button'
               onClick={() => setSortOrder((p) => (p === 'latest' ? 'oldest' : 'latest'))}
               className='h-11 w-11 flex items-center justify-center'
-              aria-label='정렬 변경'
+              aria-label={`정렬 변경, 현재 ${sortOrder === 'latest' ? '최신순' : '오래된순'}`}
             >
               <SortIcon className='w-[24px] h-[24px] text-[var(--color-grey-500)]' />
             </button>
           </div>
-          <div className='mt-4 space-y-[10px]'>
+          <div role='feed' aria-label='익명 편지 목록' aria-busy={hasMore} className='mt-4 space-y-[10px]'>
             {/* 1) 에러 */}
             {isError ? (
               <div className='flex flex-col items-center justify-center gap-8 py-30 text-center'>
@@ -178,6 +179,7 @@ export default function LetterInboxOtherPage() {
                       key={it.letterId}
                       type='button'
                       onClick={() => handleOpenThread(it)}
+                      aria-label={`${it.senderName}의 편지: ${it.letterTitle}, ${it.receivedAt}${it.isUnread ? ', 읽지 않음' : ''}`}
                       className='relative w-full h-[129px] rounded-xl bg-white p-4 text-left shadow-[0_8px_24px_rgba(0,0,0,0.06)]'
                     >
                       <div className='flex items-start justify-between gap-3'>
@@ -191,7 +193,7 @@ export default function LetterInboxOtherPage() {
                               {it.senderName}
                             </p>
                             {it.isUnread && (
-                              <span className='inline-block h-[6px] w-[6px] rounded-full bg-[#F5544C]' />
+                              <span aria-hidden='true' className='inline-block h-[6px] w-[6px] rounded-full bg-[#F5544C]' />
                             )}
                           </div>
                         </div>
@@ -230,11 +232,11 @@ export default function LetterInboxOtherPage() {
                   </div>
                 )}
                 {hasMore && (
-                  <div className='flex justify-center py-4'>
+                  <div role='status' aria-label='편지 불러오는 중' className='flex justify-center py-4'>
                     <LoadingDots fillIntervalMs={350} />
                   </div>
                 )}
-                <div ref={sentinelRef} className='h-1' />
+                <div ref={sentinelRef} aria-hidden='true' className='h-1' />
               </>
             )}
           </div>

--- a/src/pages/letter/LetterInboxOtherPage.tsx
+++ b/src/pages/letter/LetterInboxOtherPage.tsx
@@ -1,6 +1,8 @@
-import { useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { useDebouncedValue } from '@/hooks/useDebouncedValue';
 import { useNavigate } from 'react-router-dom';
+import { useIntersectionObserver } from '@/hooks/useIntersectionObserver';
+import { LoadingDots } from '@/components/LoadingDots';
 
 import TitleHeader from '@/components/common/headers/TitleHeader';
 import LetterInboxTabs, { type LetterInboxTabKey } from '@/components/LetterInboxTabs';
@@ -102,6 +104,25 @@ export default function LetterInboxOtherPage() {
     navigate(`/letter/thread/${item.sessionId}`);
   };
 
+  const PAGE_SIZE = 10;
+  const [displayCount, setDisplayCount] = useState(PAGE_SIZE);
+  const hasMore = displayCount < filtered.length;
+
+  const handleLoadMore = useCallback(() => {
+    setDisplayCount((prev) => Math.min(prev + PAGE_SIZE, filtered.length));
+  }, [filtered.length]);
+
+  const sentinelRef = useIntersectionObserver({
+    onIntersect: handleLoadMore,
+    enabled: hasMore,
+    resetKey: displayCount,
+  });
+
+  const visibleItems = useMemo(
+    () => filtered.slice(0, displayCount),
+    [filtered, displayCount],
+  );
+
   const isEmpty = !isLoading && !isError && filtered.length === 0;
 
   if (isLoading) return <InboxSkeleton />;
@@ -109,7 +130,6 @@ export default function LetterInboxOtherPage() {
   return (
     <div className='min-h-screen bg-[var(--color-bg-500)]'>
       <TitleHeader title='편지함' />
-
       <main className='px-5 pb-[95px]'>
         <div className='mx-auto w-full max-w-[343px]'>
           <LetterInboxTabs value={tab} onChange={handleTabChange} />
@@ -145,7 +165,7 @@ export default function LetterInboxOtherPage() {
               </div>
             ) : (
               /* 3) 정상 */ <>
-                {filtered.map((it) => {
+                {visibleItems.map((it) => {
                   const envelopeAsset = ENVELOPE_ASSET_MAP[it.paperId];
                   const EnvelopePreview = envelopeAsset?.Preview;
 
@@ -205,6 +225,12 @@ export default function LetterInboxOtherPage() {
                     검색 결과가 없어요
                   </div>
                 )}
+                {hasMore && (
+                  <div className='flex justify-center py-4'>
+                    <LoadingDots fillIntervalMs={350} />
+                  </div>
+                )}
+                <div ref={sentinelRef} className='h-1' />
               </>
             )}
           </div>

--- a/src/pages/letter/LetterInboxSelfPage.tsx
+++ b/src/pages/letter/LetterInboxSelfPage.tsx
@@ -121,6 +121,7 @@ export default function LetterInboxSelfPage() {
                 value={keyword}
                 onChange={(e) => setKeyword(e.target.value)}
                 placeholder='키워드를 검색해보세요'
+                aria-label='편지 검색'
                 className='w-full bg-transparent ty-body5 outline-none placeholder:text-[var(--color-text-assistive)]'
               />
             </div>
@@ -129,13 +130,13 @@ export default function LetterInboxSelfPage() {
               type='button'
               onClick={() => setSortOrder((p) => (p === 'latest' ? 'oldest' : 'latest'))}
               className='h-11 w-11 flex items-center justify-center'
-              aria-label='정렬 변경'
+              aria-label={`정렬 변경, 현재 ${sortOrder === 'latest' ? '최신순' : '오래된순'}`}
             >
               <SortIcon className='w-[24px] h-[24px] text-[var(--color-grey-500)]' />
             </button>
           </div>
 
-          <div className='mt-4 space-y-[10px]'>
+          <div role='feed' aria-label='내 편지 목록' aria-busy={hasMore} className='mt-4 space-y-[10px]'>
             {/* 1) 에러 */}
             {isError ? (
               <div className='flex flex-col items-center justify-center gap-8 py-30 text-center'>
@@ -159,6 +160,7 @@ export default function LetterInboxSelfPage() {
                       key={it.letterId}
                       type='button'
                       onClick={() => handleOpenLetter(it.letterId)}
+                      aria-label={`${it.question}: ${it.title}, ${it.receivedAt}`}
                       className='relative w-full h-[129px] rounded-xl bg-white p-4 text-left shadow-[0_8px_24px_rgba(0,0,0,0.06)]'
                     >
                       <div className='flex items-start justify-between gap-3'>
@@ -202,11 +204,11 @@ export default function LetterInboxSelfPage() {
                   );
                 })}
                 {hasMore && (
-                  <div className='flex justify-center py-4'>
+                  <div role='status' aria-label='편지 불러오는 중' className='flex justify-center py-4'>
                     <LoadingDots fillIntervalMs={350} />
                   </div>
                 )}
-                <div ref={sentinelRef} className='h-1' />
+                <div ref={sentinelRef} aria-hidden='true' className='h-1' />
               </>
             )}
           </div>

--- a/src/pages/letter/LetterInboxSelfPage.tsx
+++ b/src/pages/letter/LetterInboxSelfPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useDebouncedValue } from '@/hooks/useDebouncedValue';
 import { useNavigate } from 'react-router-dom';
 import { useIntersectionObserver } from '@/hooks/useIntersectionObserver';
@@ -81,6 +81,10 @@ export default function LetterInboxSelfPage() {
 
   const PAGE_SIZE = 10;
   const [displayCount, setDisplayCount] = useState(PAGE_SIZE);
+
+  useEffect(() => {
+    setDisplayCount(PAGE_SIZE);
+  }, [debouncedKeyword, sortOrder]);
   const hasMore = displayCount < filtered.length;
 
   const handleLoadMore = useCallback(() => {

--- a/src/pages/letter/LetterInboxSelfPage.tsx
+++ b/src/pages/letter/LetterInboxSelfPage.tsx
@@ -1,6 +1,8 @@
-import { useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { useDebouncedValue } from '@/hooks/useDebouncedValue';
 import { useNavigate } from 'react-router-dom';
+import { useIntersectionObserver } from '@/hooks/useIntersectionObserver';
+import { LoadingDots } from '@/components/LoadingDots';
 
 import TitleHeader from '@/components/common/headers/TitleHeader';
 import LetterInboxTabs, { type LetterInboxTabKey } from '@/components/LetterInboxTabs';
@@ -77,6 +79,25 @@ export default function LetterInboxSelfPage() {
     });
   };
 
+  const PAGE_SIZE = 10;
+  const [displayCount, setDisplayCount] = useState(PAGE_SIZE);
+  const hasMore = displayCount < filtered.length;
+
+  const handleLoadMore = useCallback(() => {
+    setDisplayCount((prev) => Math.min(prev + PAGE_SIZE, filtered.length));
+  }, [filtered.length]);
+
+  const sentinelRef = useIntersectionObserver({
+    onIntersect: handleLoadMore,
+    enabled: hasMore,
+    resetKey: displayCount,
+  });
+
+  const visibleItems = useMemo(
+    () => filtered.slice(0, displayCount),
+    [filtered, displayCount],
+  );
+
   const isEmpty = !isLoading && !isError && filtered.length === 0;
 
   if (isLoading) return <InboxSkeleton />;
@@ -84,7 +105,6 @@ export default function LetterInboxSelfPage() {
   return (
     <div className='min-h-screen bg-[var(--color-bg-500)]'>
       <TitleHeader title='편지함' />
-
       <main className='px-5 pb-[95px]'>
         <div className='mx-auto w-full max-w-[343px]'>
           <LetterInboxTabs value={tab} onChange={handleTabChange} />
@@ -126,7 +146,7 @@ export default function LetterInboxSelfPage() {
               </div>
             ) : (
               /* 4) 정상 */ <>
-                {filtered.map((it) => {
+                {visibleItems.map((it) => {
                   const envelopeAsset = ENVELOPE_ASSET_MAP[it.paperId];
                   const EnvelopePreview = envelopeAsset?.Preview;
 
@@ -177,6 +197,12 @@ export default function LetterInboxSelfPage() {
                     </button>
                   );
                 })}
+                {hasMore && (
+                  <div className='flex justify-center py-4'>
+                    <LoadingDots fillIntervalMs={350} />
+                  </div>
+                )}
+                <div ref={sentinelRef} className='h-1' />
               </>
             )}
           </div>


### PR DESCRIPTION
## 📂 관련 이슈

- closes #176 

---

## 🛠️ 작업 사항

- [x] 피드페이지 무한 스크롤 구현
- [x] 메일함 - 익명 편지 페이지 조회 무한 스크롤 구현
- [x] 메일함 - 나에게 보내는 편지 페이지 조회 무한 스크롤 구현

---

## 📸 관련 이미지 (스크린샷 또는 동영상)

---

## 💬 기타 설명

> 💡 추가적으로 공유할 내용이나 리뷰어에게 전달할 사항이 있다면 작성해 주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 피드 및 레터 받은편지함에 클라이언트 사이드 무한 스크롤 도입 — 아래로 스크롤 시 자동으로 항목을 점진 로드
  * 로드 중일 때 화면에 로딩 표시기(로딩 도트) 노출 및 더 이상 항목이 없을 때 처리

* **접근성**
  * 피드와 목록에 ARIA 속성 추가(로딩 상태, 항목 설명, 버튼 레이블 등)로 스크린리더 반응 개선

* **스타일**
  * 헤더 배경 색상 참조 방식 개선(스타일 안정성 향상)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->