### PR TITLE
[fix] /auth/pw-find 뒤로가기 시 /auth/signin 루프 수정

### DIFF
--- a/src/pages/login/FindAccountPAge.tsx
+++ b/src/pages/login/FindAccountPAge.tsx
@@ -58,8 +58,8 @@ const FindAccountPage = () => {
       return;
     }
 
-    // 2. 탭의 첫 화면(메인) 상태에서 뒤로가기를 누르면 서비스 진입점(로그인 등)으로 탈출
-    navigate('/auth/signin');
+    // 2. 탭의 첫 화면(메인) 상태에서 뒤로가기를 누르면 이전 페이지로 복귀
+    navigate(-1);
   };
 
   return (


### PR DESCRIPTION
## 📂 관련 이슈

- closes #189 

---

## 🛠️ 작업 사항

- [x] 원인 파악 후 해결
---

## 📸 관련 이미지 (스크린샷 또는 동영상)

---

## 💬 기타 설명

> 💡 추가적으로 공유할 내용이나 리뷰어에게 전달할 사항이 있다면 작성해 주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정

* 계정 찾기 페이지의 뒤로 가기 버튼 동작을 개선했습니다. 이제 로그인 페이지로 바로 이동하는 대신 이전 페이지로 돌아갑니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->