### PR TITLE
[Refactor] 피드 및 카드 컴포넌트 Memoization 적용 및 불필요한 함수 재생성 방지

### DIFF
--- a/src/components/feed/FeedPageTemplate.tsx
+++ b/src/components/feed/FeedPageTemplate.tsx
@@ -72,12 +72,14 @@ export default function FeedPageTemplate({
 
   const visibleLetters = useMemo(() => letters.slice(0, displayCount), [letters, displayCount]);
 
-  const handleToggleLike = (letterId: number, isLiked: boolean) => {
-    if (createLike.isPending || deleteLike.isPending) return;
-
-    if (isLiked) deleteLike.mutate(letterId);
-    else createLike.mutate(letterId);
-  };
+  const handleToggleLike = useCallback(
+    (letterId: number, isLiked: boolean) => {
+      if (createLike.isPending || deleteLike.isPending) return;
+      if (isLiked) deleteLike.mutate(letterId);
+      else createLike.mutate(letterId);
+    },
+    [createLike, deleteLike],
+  );
 
   const deadlineMs = useMemo(() => {
     if (!questionData?.expiredAt) return null;
@@ -123,6 +125,7 @@ export default function FeedPageTemplate({
         {visibleLetters.map((l) => (
           <LetterPreviewCard
             key={l.letterId}
+            letterId={l.letterId}
             title={l.title}
             content={l.content}
             paperId={l.paperId}
@@ -133,7 +136,7 @@ export default function FeedPageTemplate({
               (createLike.isPending && createLike.variables === l.letterId) ||
               (deleteLike.isPending && deleteLike.variables === l.letterId)
             }
-            onToggleLike={() => handleToggleLike(l.letterId, l.isLiked)}
+            onToggleLike={handleToggleLike}
           />
         ))}
         {!hasMore && letters.length <= 1 && <EmptyFeedCard />}

--- a/src/components/feed/LetterPreviewCard.tsx
+++ b/src/components/feed/LetterPreviewCard.tsx
@@ -190,7 +190,8 @@ function areEqual(prevProps: LetterPreviewCardProps, nextProps: LetterPreviewCar
     prevProps.likes === nextProps.likes &&
     prevProps.isLiked === nextProps.isLiked &&
     prevProps.disabled === nextProps.disabled &&
-    prevProps.isLikeLoading === nextProps.isLikeLoading
+    prevProps.isLikeLoading === nextProps.isLikeLoading &&
+    prevProps.onToggleLike === nextProps.onToggleLike
   );
 }
 

--- a/src/components/feed/LetterPreviewCard.tsx
+++ b/src/components/feed/LetterPreviewCard.tsx
@@ -1,18 +1,21 @@
-import { DEFAULT_THEME, PAPER_THEME } from '@/constants/paperTheme';
-import { useState } from 'react';
+import { memo, useState } from 'react';
+import { PAPER_THEME, DEFAULT_THEME } from '@/constants/paperTheme';
 
 interface LetterPreviewCardProps {
+  letterId: number;
   title: string;
   content: string;
   paperId: number;
   likes: number;
   isLiked: boolean;
-  onToggleLike?: () => void;
+  // eslint-disable-next-line no-unused-vars
+  onToggleLike?: (letterId: number, isLiked: boolean) => void;
   disabled?: boolean;
   isLikeLoading?: boolean;
 }
 
-export default function LetterPreviewCard({
+function LetterPreviewCard({
+  letterId,
   title,
   content,
   paperId,
@@ -22,6 +25,14 @@ export default function LetterPreviewCard({
   disabled,
   isLikeLoading,
 }: LetterPreviewCardProps) {
+  console.log('LetterPreviewCard 렌더', {
+    letterId,
+    title,
+    likes,
+    isLiked,
+    isLikeLoading,
+    disabled,
+  });
   const [isExpanded, setIsExpanded] = useState(false);
 
   const theme = PAPER_THEME[paperId] ?? DEFAULT_THEME;
@@ -116,7 +127,12 @@ export default function LetterPreviewCard({
         {/* 좋아요 */}
         <div className='flex items-center gap-1 justify-end'>
           <button
-            onClick={onToggleLike}
+            onClick={() => {
+              console.log('LetterPreviewCard 좋아요 클릭', { letterId, isLiked });
+              if (onToggleLike) {
+                onToggleLike(letterId, isLiked);
+              }
+            }}
             disabled={disabled}
             className='flex items-center justify-center w-[22px] h-[22px] disabled:opacity-50'
           >
@@ -164,3 +180,18 @@ export default function LetterPreviewCard({
     </div>
   );
 }
+
+function areEqual(prevProps: LetterPreviewCardProps, nextProps: LetterPreviewCardProps) {
+  return (
+    prevProps.letterId === nextProps.letterId &&
+    prevProps.title === nextProps.title &&
+    prevProps.content === nextProps.content &&
+    prevProps.paperId === nextProps.paperId &&
+    prevProps.likes === nextProps.likes &&
+    prevProps.isLiked === nextProps.isLiked &&
+    prevProps.disabled === nextProps.disabled &&
+    prevProps.isLikeLoading === nextProps.isLikeLoading
+  );
+}
+
+export default memo(LetterPreviewCard, areEqual);

--- a/src/components/feed/LetterPreviewCard.tsx
+++ b/src/components/feed/LetterPreviewCard.tsx
@@ -25,14 +25,6 @@ function LetterPreviewCard({
   disabled,
   isLikeLoading,
 }: LetterPreviewCardProps) {
-  console.log('LetterPreviewCard 렌더', {
-    letterId,
-    title,
-    likes,
-    isLiked,
-    isLikeLoading,
-    disabled,
-  });
   const [isExpanded, setIsExpanded] = useState(false);
 
   const theme = PAPER_THEME[paperId] ?? DEFAULT_THEME;
@@ -128,7 +120,6 @@ function LetterPreviewCard({
         <div className='flex items-center gap-1 justify-end'>
           <button
             onClick={() => {
-              console.log('LetterPreviewCard 좋아요 클릭', { letterId, isLiked });
               if (onToggleLike) {
                 onToggleLike(letterId, isLiked);
               }

--- a/src/components/letters/LetterCarousel.tsx
+++ b/src/components/letters/LetterCarousel.tsx
@@ -7,7 +7,7 @@ interface LetterCarouselProps {
   letters: FeedLetter[];
   emptyMessage?: string;
   // eslint-disable-next-line no-unused-vars
-  onLetterClick?: (letter: FeedLetter) => void;
+  onLetterClick?: (letterId: number) => void;
 }
 
 export default function LetterCarousel({
@@ -49,10 +49,10 @@ export default function LetterCarousel({
   }, []);
 
   const handleCardClick = useCallback(
-    (letter: FeedLetter) => {
+    (letterId: number) => {
       // 드래그 중이었다면 클릭 이벤트 무시
       if (isDraggingRef.current) return;
-      onLetterClick?.(letter);
+      onLetterClick?.(letterId);
     },
     [onLetterClick],
   );
@@ -211,7 +211,7 @@ export default function LetterCarousel({
                 className='flex-shrink-0'
                 style={{ width: `${CARD_WIDTH}px` }}
               >
-                <LetterItem letter={letter} onClick={() => handleCardClick(letter)} />
+                <LetterItem letter={letter} onClick={handleCardClick} />
               </div>
             ))}
           </div>

--- a/src/components/letters/LetterItem.tsx
+++ b/src/components/letters/LetterItem.tsx
@@ -4,7 +4,8 @@ import { formatDate } from '@/utils/date';
 
 interface LetterItemProps {
   letter: FeedLetter;
-  onClick: () => void;
+  // eslint-disable-next-line no-unused-vars
+  onClick: (letterId: number) => void;
 }
 
 export default function LetterItem({ letter, onClick }: LetterItemProps) {
@@ -13,7 +14,7 @@ export default function LetterItem({ letter, onClick }: LetterItemProps) {
 
   return (
     <button
-      onClick={onClick}
+      onClick={() => onClick(letter.letterId)}
       className='relative w-full transition-all duration-300 ease-out hover:scale-105 focus:outline-none'
       aria-label={`${letter.title} 편지 열기`}
       style={{


### PR DESCRIPTION
## 📂 관련 이슈

- closes #192 

---

## 🛠️ 작업 사항

- [x] LetterPreviewCard에 React.memo 적용 (좋아요 클릭시 전체 리스트 리렌더링 방지)
- [x] 피드페이지 handleToggleLike 함수 useCallback으로 래핑
- [x] 캐러셀 컴포넌트 인라인 함수 제거 및 핸들러 최적화
---

## 📸 관련 이미지 (스크린샷 또는 동영상)

---

## 💬 기타 설명

> 💡 추가적으로 공유할 내용이나 리뷰어에게 전달할 사항이 있다면 작성해 주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **성능 개선**
  * 컴포넌트 메모이제이션을 통해 피드 렌더링 성능 최적화
  * 라이크 기능의 콜백 처리 효율성 개선으로 응답성 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->