### PR TITLE
[Bug] stampId와 paperId 매핑 버그 해결

### DIFF
--- a/src/constants/envelopeAssets.ts
+++ b/src/constants/envelopeAssets.ts
@@ -14,7 +14,7 @@ export type EnvelopeAsset = {
   Preview: React.ComponentType<{ className?: string }>;
 };
 
-export const ENVELOPE_ASSET_MAP: Record<number, EnvelopeAsset> = {
+export const ENVELOPE_ASSET_MAP: Record<string | number, EnvelopeAsset> = {
   1: { label: 'Mint', Preview: mint },
   2: { label: 'Purple', Preview: purple },
   3: { label: 'Blue', Preview: blue },
@@ -24,4 +24,15 @@ export const ENVELOPE_ASSET_MAP: Record<number, EnvelopeAsset> = {
   7: { label: 'Beige', Preview: beige },
   8: { label: 'Vintage', Preview: vintage },
   9: { label: 'Grey', Preview: grey },
+
+  // 2. 새로운 문자열 기반 추가 (서버 응답값 대응)
+  Mint: { label: 'Mint', Preview: mint },
+  Purple: { label: 'Purple', Preview: purple },
+  Blue: { label: 'Blue', Preview: blue },
+  Yellow: { label: 'Yellow', Preview: yellow },
+  Pink: { label: 'Pink', Preview: pink },
+  Paper: { label: 'Paper', Preview: paper },
+  Beige: { label: 'Beige', Preview: beige },
+  Vintage: { label: 'Vintage', Preview: vintage },
+  Grey: { label: 'Grey', Preview: grey },
 };

--- a/src/constants/envelopeAssets.ts
+++ b/src/constants/envelopeAssets.ts
@@ -25,7 +25,7 @@ export const ENVELOPE_ASSET_MAP: Record<string | number, EnvelopeAsset> = {
   8: { label: 'Vintage', Preview: vintage },
   9: { label: 'Grey', Preview: grey },
 
-  // 2. 새로운 문자열 기반 추가 (서버 응답값 대응)
+  // 새로운 문자열 기반 추가 (서버 응답값 대응)
   Mint: { label: 'Mint', Preview: mint },
   Purple: { label: 'Purple', Preview: purple },
   Blue: { label: 'Blue', Preview: blue },

--- a/src/pages/friend/FriendInboxPage.tsx
+++ b/src/pages/friend/FriendInboxPage.tsx
@@ -44,8 +44,8 @@ export default function FriendInboxPage() {
         const ms = iso ? new Date(iso).getTime() : 0;
         const paperColor = f.recentLetter?.design?.paper?.color;
         const paperId = f.recentLetter?.design?.paper?.id;
-        const stampColor = f.recentLetter?.design?.paper?.color;
-        const stampId = f.recentLetter?.design?.paper?.id;
+        const stampColor = f.recentLetter?.design?.stamp?.name;
+        const stampId = f.recentLetter?.design?.stamp?.id;
 
         return {
           id: f.id,
@@ -57,8 +57,8 @@ export default function FriendInboxPage() {
           lastDate: iso ? formatDate(iso) : '-', // UI용
           lastAtMs: Number.isNaN(ms) ? 0 : ms, // 정렬용
 
-          paperId: paperColor || (paperId !== undefined ? paperId + 1 : 1),
-          stampId: stampColor || (stampId !== undefined ? stampId + 1 : 1),
+          paperId: paperColor || (paperId !== undefined ? paperId : 1),
+          stampId: stampColor || (stampId !== undefined ? stampId : 1),
           stampUrl: (f.recentLetter?.design?.stamp?.assetUrl ?? '').trim(),
         };
       }),

--- a/src/pages/friend/FriendInboxPage.tsx
+++ b/src/pages/friend/FriendInboxPage.tsx
@@ -19,8 +19,8 @@ type FriendInboxItem = {
   exchangeCount: number;
   lastDate: string; // '2026.1.3'
   lastAtMs: number;
-  paperId: number;
-  stampId: number;
+  paperId: string | number;
+  stampId: string | number;
   stampUrl: string;
 };
 
@@ -42,6 +42,10 @@ export default function FriendInboxPage() {
       friends.map((f) => {
         const iso = f.recentLetter?.createdAt ?? null;
         const ms = iso ? new Date(iso).getTime() : 0;
+        const paperColor = f.recentLetter?.design?.paper?.color;
+        const paperId = f.recentLetter?.design?.paper?.id;
+        const stampColor = f.recentLetter?.design?.paper?.color;
+        const stampId = f.recentLetter?.design?.paper?.id;
 
         return {
           id: f.id,
@@ -53,8 +57,8 @@ export default function FriendInboxPage() {
           lastDate: iso ? formatDate(iso) : '-', // UI용
           lastAtMs: Number.isNaN(ms) ? 0 : ms, // 정렬용
 
-          paperId: Number(f.recentLetter?.design.paper?.id ?? 0),
-          stampId: Number(f.recentLetter?.design.stamp?.id ?? 0),
+          paperId: paperColor || (paperId !== undefined ? paperId + 1 : 1),
+          stampId: stampColor || (stampId !== undefined ? stampId + 1 : 1),
           stampUrl: (f.recentLetter?.design?.stamp?.assetUrl ?? '').trim(),
         };
       }),

--- a/src/pages/friend/FriendInboxPage.tsx
+++ b/src/pages/friend/FriendInboxPage.tsx
@@ -44,7 +44,7 @@ export default function FriendInboxPage() {
         const ms = iso ? new Date(iso).getTime() : 0;
         const paperColor = f.recentLetter?.design?.paper?.color;
         const paperId = f.recentLetter?.design?.paper?.id;
-        const stampColor = f.recentLetter?.design?.stamp?.name;
+        const stampName = f.recentLetter?.design?.stamp?.name;
         const stampId = f.recentLetter?.design?.stamp?.id;
 
         return {
@@ -58,7 +58,7 @@ export default function FriendInboxPage() {
           lastAtMs: Number.isNaN(ms) ? 0 : ms, // 정렬용
 
           paperId: paperColor || (paperId !== undefined ? paperId : 1),
-          stampId: stampColor || (stampId !== undefined ? stampId : 1),
+          stampId: stampName || (stampId !== undefined ? stampId : 1),
           stampUrl: (f.recentLetter?.design?.stamp?.assetUrl ?? '').trim(),
         };
       }),

--- a/src/pages/friend/FriendInboxPage.tsx
+++ b/src/pages/friend/FriendInboxPage.tsx
@@ -141,9 +141,9 @@ export default function FriendInboxPage() {
                     <div className='h-12 w-12 shrink-0 rounded-full bg-[var(--color-primary-100)] overflow-hidden flex items-center justify-center'>
                       {f.profileImageUrl ? (
                         <img
-                          src={`${f.profileImageUrl}?t=${cacheBuster}`}
+                          src={`${f.profileImageUrl}${f.profileImageUrl.includes('?') ? '&' : '?'}t=${cacheBuster}`}
                           alt='프로필'
-                          className='w-full h-full object-cover '
+                          className='w-full h-full object-cover'
                         />
                       ) : (
                         /* 이미지가 없을 때 보여줄 빈 화면 */

--- a/src/pages/main/Mainpage.tsx
+++ b/src/pages/main/Mainpage.tsx
@@ -92,7 +92,7 @@ const MainPage = () => {
           timeLeft={timeLeft}
           profileImageUrl={
             homeSummary?.user?.profileImageUrl
-              ? `${homeSummary.user.profileImageUrl}?t=${profileImageCacheBuster}`
+              ? `${homeSummary.user.profileImageUrl}${homeSummary.user.profileImageUrl.includes('?') ? '&' : '?'}t=${profileImageCacheBuster}`
               : undefined
           }
         />

--- a/src/types/dto/friend.ts
+++ b/src/types/dto/friend.ts
@@ -8,8 +8,8 @@ export type FriendApiResponse<T> = CommonResponse<{
 export type RecentLetter = {
   createdAt: string;
   design: {
-    paper: { id: number; color: string };
-    stamp: { id: number; name: string; assetUrl: string };
+    paper: { id?: number; color: string };
+    stamp: { id?: number; name: string; assetUrl: string };
   };
 };
 


### PR DESCRIPTION
## 📂 관련 이슈

- closes #201 

---

## 🛠️ 작업 사항

- [x] envelopAsset에 string 으로 리스폰스 바디를 받을 때 로직 추가
- [x] url 겹치는 에러 방지 위해 url 붙이는 로직 개선

---

## 📸 관련 이미지 (스크린샷 또는 동영상)

---
<img width="200" height="518" alt="스크린샷 2026-02-12 오후 6 05 15" src="https://github.com/user-attachments/assets/111d8057-7730-4817-998e-8b96b3e856be" />


## 💬 기타 설명

> 💡 추가적으로 공유할 내용이나 리뷰어에게 전달할 사항이 있다면 작성해 주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 봉투 자산을 문자열(예: Mint, Purple 등) 및 숫자 키로 모두 조회할 수 있도록 확장했습니다.

* **Bug Fixes**
  * 프로필 이미지 URL에 캐시 무효화 파라미터를 기존 쿼리와 충돌 없이 올바르게 추가하도록 개선했습니다.

* **Refactor**
  * 수신함 항목의 종이/우표 식별자를 문자열 또는 숫자로 허용하도록 유연성 향상.
  * 편지 디자인의 일부 ID 필드를 선택사항으로 변경했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->